### PR TITLE
Don't fail getNodeAction if the forward-checking of child permissions check fails

### DIFF
--- a/cadc-vos-server/build.gradle
+++ b/cadc-vos-server/build.gradle
@@ -14,7 +14,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.0.7'
+version = '1.0.8'
 
 dependencies {
     compile 'log4j:log4j:1.2.+'

--- a/cadc-vos-server/src/main/java/ca/nrc/cadc/vos/server/web/restlet/action/GetNodeAction.java
+++ b/cadc-vos-server/src/main/java/ca/nrc/cadc/vos/server/web/restlet/action/GetNodeAction.java
@@ -428,6 +428,11 @@ public class GetNodeAction extends NodeAction
         {
             // no read access, continue
         }
+        catch (Exception e)
+        {
+            // error checking access, log a warning
+            log.warn("Failed to check read permission", e);
+        }
     }
 
     /**
@@ -450,6 +455,11 @@ public class GetNodeAction extends NodeAction
         catch (AccessControlException e)
         {
             // no write access, continue
+        }
+        catch (Exception e)
+        {
+            // error checking access, log a warning
+            log.warn("Failed to check write permission", e);
         }
     }
 }

--- a/cadc-vos-server/src/main/java/ca/nrc/cadc/vos/server/web/restlet/action/GetNodeAction.java
+++ b/cadc-vos-server/src/main/java/ca/nrc/cadc/vos/server/web/restlet/action/GetNodeAction.java
@@ -386,6 +386,13 @@ public class GetNodeAction extends NodeAction
                 log.debug("doFilterChildren: remove " + n);
                 iter.remove();
             }
+            catch (Exception e)
+            {
+                // error checking access, log a warning
+                log.warn("Failed to check read permission", e);
+                log.debug("doFilterChildren: remove due to auth check error " + n);
+                iter.remove();
+            }
         }
 
         // since a limit isn't supplied to node persistence when getting


### PR DESCRIPTION
When calling a remote GMS service, the user's proxy cert may not have a recognized certificate authority.  This should not cause the entire get node action to fail.