### PR TITLE
removed the forced posixGroup

### DIFF
--- a/cavern/src/main/java/org/opencadc/cavern/FileSystemNodePersistence.java
+++ b/cavern/src/main/java/org/opencadc/cavern/FileSystemNodePersistence.java
@@ -106,7 +106,6 @@ public class FileSystemNodePersistence implements NodePersistence {
 
     private PosixIdentityManager identityManager;
     private Path root;
-    private GroupPrincipal posixGroup;
 
     public FileSystemNodePersistence() {
         PropertiesReader pr = new PropertiesReader("Cavern.properties");
@@ -115,23 +114,7 @@ public class FileSystemNodePersistence implements NodePersistence {
             throw new RuntimeException("CONFIG: Failed to find VOS_FILESYSTEM_ROOT");
         }
         this.root = Paths.get(rootConfig);
-
         this.identityManager = new PosixIdentityManager(root.getFileSystem().getUserPrincipalLookupService());
-        String groupConfig = getPosixGroupFromConfig();
-        try {
-            this.posixGroup = root.getFileSystem().getUserPrincipalLookupService().lookupPrincipalByGroupName(groupConfig);
-        } catch (IOException ex) {
-            throw new RuntimeException("CONFIG: failed to lookup posix group: " + groupConfig, ex);
-        }
-    }
-
-    private String getPosixGroupFromConfig() {
-        PropertiesReader pr = new PropertiesReader("Cavern.properties");
-        String groupConfig = pr.getFirstPropertyValue("POSIX_GROUP");
-        if (groupConfig == null) {
-            throw new RuntimeException("CONFIG: Failed to find POSIX_GROUP");
-        }
-        return groupConfig;
     }
 
     @Override
@@ -242,7 +225,7 @@ public class FileSystemNodePersistence implements NodePersistence {
             Subject s = AuthenticationUtil.getCurrentSubject();
             UserPrincipal owner = identityManager.toUserPrincipal(s);
             NodeUtil.setOwner(node, owner);
-            NodeUtil.create(root, node, posixGroup);
+            NodeUtil.create(root, node);
             return NodeUtil.get(root, node.getUri());
         } catch (IOException ex) {
             throw new RuntimeException("oops", ex);
@@ -300,7 +283,7 @@ public class FileSystemNodePersistence implements NodePersistence {
         try {
             Subject s = AuthenticationUtil.getCurrentSubject();
             UserPrincipal owner = identityManager.toUserPrincipal(s);
-            NodeUtil.move(root, node.getUri(), cn.getUri(), owner, posixGroup);
+            NodeUtil.move(root, node.getUri(), cn.getUri(), owner);
         } catch (IOException ex) {
             throw new RuntimeException("oops", ex);
         }
@@ -315,7 +298,7 @@ public class FileSystemNodePersistence implements NodePersistence {
         try {
             Subject s = AuthenticationUtil.getCurrentSubject();
             UserPrincipal owner = identityManager.toUserPrincipal(s);
-            NodeUtil.copy(root, node.getUri(), cn.getUri(), owner, posixGroup);
+            NodeUtil.copy(root, node.getUri(), cn.getUri(), owner);
         } catch (IOException ex) {
             throw new RuntimeException("oops", ex);
         }

--- a/cavern/src/main/java/org/opencadc/cavern/ServiceAvailability.java
+++ b/cavern/src/main/java/org/opencadc/cavern/ServiceAvailability.java
@@ -130,11 +130,9 @@ public class ServiceAvailability implements WebService {
             log.debug("owner: " + owner);
             String linkTargetOwner = pr.getFirstPropertyValue("PROBE_LINKOWER");
             log.debug("linkTargetOwner: " + linkTargetOwner);
-            String group = pr.getFirstPropertyValue("PROBE_GROUP");
-            log.debug("group: " + group);
             File root = new File(rootPath);
 
-            FileSystemProbe fsp = new FileSystemProbe(root, owner, linkTargetOwner, group);
+            FileSystemProbe fsp = new FileSystemProbe(root, owner, linkTargetOwner);
             Boolean success = fsp.call();
             if (success == null || !success) {
                 return new AvailabilityStatus(false, null, null, null, "File system probe failed");

--- a/cavern/src/main/java/org/opencadc/cavern/files/PutAction.java
+++ b/cavern/src/main/java/org/opencadc/cavern/files/PutAction.java
@@ -82,6 +82,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.GroupPrincipal;
 import java.nio.file.attribute.UserPrincipal;
 import java.security.AccessControlException;
 
@@ -138,6 +139,7 @@ public class PutAction extends FileAction {
             }
 
             UserPrincipal owner = NodeUtil.getOwner(getUpLookupSvc(), node);
+            GroupPrincipal group = NodeUtil.getDefaultGroup(getUpLookupSvc(), owner);
 
             // only support data nodes for now
             if (!(DataNode.class.isAssignableFrom(node.getClass()))) {
@@ -153,7 +155,7 @@ public class PutAction extends FileAction {
             log.debug("Completed copy to file: " + target);
 
             log.debug("Restoring original permissions");
-            NodeUtil.applyPermissions(rootPath, target, getPosixGroup(), owner);
+            NodeUtil.applyPermissions(rootPath, target, owner, group);
         } catch (AccessControlException | AccessDeniedException e) {
             log.debug(e);
             syncOutput.setCode(403);

--- a/cavern/src/main/java/org/opencadc/cavern/probe/FileSystemProbe.java
+++ b/cavern/src/main/java/org/opencadc/cavern/probe/FileSystemProbe.java
@@ -99,14 +99,12 @@ public class FileSystemProbe implements Callable<Boolean> {
     private final UserPrincipal owner;
     private final UserPrincipal linkTargetOwner;
     private final UserPrincipalLookupService users;
-    private final GroupPrincipal group;
 
-    public FileSystemProbe(File baseDir, String owner, String linkTargetOwner, String group) throws IOException {
+    public FileSystemProbe(File baseDir, String owner, String linkTargetOwner) throws IOException {
         this.root = FileSystems.getDefault().getPath(baseDir.getAbsolutePath());
         this.users = root.getFileSystem().getUserPrincipalLookupService();
         this.owner = users.lookupPrincipalByName(owner);
         this.linkTargetOwner = users.lookupPrincipalByName(linkTargetOwner);
-        this.group = users.lookupPrincipalByGroupName(group);
     }
 
     @Override
@@ -157,7 +155,7 @@ public class FileSystemProbe implements Callable<Boolean> {
             log.info("[dir] " +  n1.getClass().getSimpleName() + " " + n1.getUri() + " " + owner);
 
             String fail = " [FAIL]";
-            Path pth = NodeUtil.create(root, n1, group);
+            Path pth = NodeUtil.create(root, n1);
             if (pth == null || !Files.exists(pth)) {
                 log.error("[dir] failed to create directory in fs: " + root + "/" + name + fail);
                 return false;
@@ -212,7 +210,7 @@ public class FileSystemProbe implements Callable<Boolean> {
             log.info("[file] " +  n1.getClass().getSimpleName() + " " + n1.getUri() + " " + owner);
 
             String fail = " [FAIL]";
-            Path pth = NodeUtil.create(root, n1, group);
+            Path pth = NodeUtil.create(root, n1);
             if (pth == null || !Files.exists(pth)) {
                 log.error("[file] failed to create file in fs: " + root + "/" + name + fail);
                 return false;
@@ -272,13 +270,13 @@ public class FileSystemProbe implements Callable<Boolean> {
             log.info("[symlink] " +  n1.getClass().getSimpleName() + " " + n1.getUri() + " " + owner);
 
             String fail = " [FAIL]";
-            Path tp = NodeUtil.create(root, tn, group);
+            Path tp = NodeUtil.create(root, tn);
             if (tp == null || !Files.exists(tp)) {
                 log.error("[symlink] failed to create file in fs: " + root + "/" + name + fail);
                 return false;
             }
 
-            Path pth = NodeUtil.create(root, n1, group);
+            Path pth = NodeUtil.create(root, n1);
             if (pth == null || !Files.exists(pth)) {
                 log.error("[symlink] failed to create symlink in fs: " + root + "/" + name + fail);
                 return false;
@@ -374,28 +372,28 @@ public class FileSystemProbe implements Callable<Boolean> {
             String fail = " [FAIL]";
 
             log.info("[copyfile] " +  srcDir.getClass().getSimpleName() + " " + srcDir.getUri() + " " + owner);
-            pth = NodeUtil.create(root, srcDir, group);
+            pth = NodeUtil.create(root, srcDir);
             if (pth == null || !Files.isDirectory(pth)) {
                 log.error("[copyfile] failed to create directory in fs: " + root + "/" + srcDir.getUri() + fail);
                 return false;
             }
 
             log.info("[copyfile] " +  destDir.getClass().getSimpleName() + " " + destDir.getUri() + " " + owner);
-            pth = NodeUtil.create(root, destDir, group);
+            pth = NodeUtil.create(root, destDir);
             if (pth == null || !Files.isDirectory(pth)) {
                 log.error("[copyfile] failed to create directory in fs: " + root + "/" + destDir.getUri() + fail);
                 return false;
             }
 
             log.info("[copyfile] " +  dn.getClass().getSimpleName() + " " + dn.getUri() + " " + owner);
-            pth = NodeUtil.create(root, dn, group);
+            pth = NodeUtil.create(root, dn);
             if (pth == null || !Files.exists(pth)) {
                 log.error("[copyfile] failed to create file in fs: " + root + "/" + dn.getUri() + fail);
                 return false;
             }
 
             int num = 0;
-            NodeUtil.copy(root, dn.getUri(), destDir.getUri(), owner, group);
+            NodeUtil.copy(root, dn.getUri(), destDir.getUri(), owner);
             VOSURI expected = new VOSURI(URI.create("vos://canfar.net~cavern/" + name2 + "/" + name3));
             Node copied = NodeUtil.get(root, expected);
             if (copied == null || !(copied instanceof DataNode)) {
@@ -448,28 +446,28 @@ public class FileSystemProbe implements Callable<Boolean> {
             String fail = " [FAIL]";
 
             log.info("[movefile] " +  srcDir.getClass().getSimpleName() + " " + srcDir.getUri() + " " + owner);
-            pth = NodeUtil.create(root, srcDir, group);
+            pth = NodeUtil.create(root, srcDir);
             if (pth == null || !Files.isDirectory(pth)) {
                 log.error("[movefile] failed to create directory in fs: " + root + "/" + srcDir.getUri() + fail);
                 return false;
             }
 
             log.info("[movefile] " +  destDir.getClass().getSimpleName() + " " + destDir.getUri() + " " + owner);
-            pth = NodeUtil.create(root, destDir, group);
+            pth = NodeUtil.create(root, destDir);
             if (pth == null || !Files.isDirectory(pth)) {
                 log.error("[movefile] failed to create directory in fs: " + root + "/" + destDir.getUri() + fail);
                 return false;
             }
 
             log.info("[movefile] " +  dn.getClass().getSimpleName() + " " + dn.getUri() + " " + owner);
-            pth = NodeUtil.create(root, dn, group);
+            pth = NodeUtil.create(root, dn);
             if (pth == null || !Files.exists(pth)) {
                 log.error("[movefile] failed to create file in fs: " + root + "/" + dn.getUri() + fail);
                 return false;
             }
 
             int num = 0;
-            NodeUtil.move(root, dn.getUri(), destDir.getUri(), owner, group);
+            NodeUtil.move(root, dn.getUri(), destDir.getUri(), owner);
             VOSURI expected = new VOSURI(URI.create("vos://canfar.net~cavern/" + name2 + "/" + name3));
             Node moved = NodeUtil.get(root, expected);
             if (moved == null || !(moved instanceof DataNode)) {
@@ -515,28 +513,28 @@ public class FileSystemProbe implements Callable<Boolean> {
             String fail = " [FAIL]";
 
             log.info("[copydir] " +  srcDir.getClass().getSimpleName() + " " + srcDir.getUri() + " " + owner);
-            pth = NodeUtil.create(root, srcDir, group);
+            pth = NodeUtil.create(root, srcDir);
             if (pth == null || !Files.isDirectory(pth)) {
                 log.error("[copydir] failed to create directory in fs: " + root + "/" + srcDir.getUri() + fail);
                 return false;
             }
 
             log.info("[copydir] " +  destDir.getClass().getSimpleName() + " " + destDir.getUri() + " " + owner);
-            pth = NodeUtil.create(root, destDir, group);
+            pth = NodeUtil.create(root, destDir);
             if (pth == null || !Files.isDirectory(pth)) {
                 log.error("[copydir] failed to create directory in fs: " + root + "/" + destDir.getUri() + fail);
                 return false;
             }
 
             log.info("[copydir] " +  dn.getClass().getSimpleName() + " " + dn.getUri() + " " + owner);
-            pth = NodeUtil.create(root, dn, group);
+            pth = NodeUtil.create(root, dn);
             if (pth == null || !Files.exists(pth)) {
                 log.error("[copydir] failed to create file in fs: " + root + "/" + dn.getUri() + fail);
                 return false;
             }
 
             int num = 0;
-            NodeUtil.copy(root, srcDir.getUri(), destDir.getUri(), owner, group);
+            NodeUtil.copy(root, srcDir.getUri(), destDir.getUri(), owner);
             VOSURI expected = new VOSURI(URI.create("vos://canfar.net~cavern/" + name2 + "/" + name1 + "/" + name3));
             Node copied = NodeUtil.get(root, expected);
             if (copied == null || !(copied instanceof DataNode)) {
@@ -589,28 +587,28 @@ public class FileSystemProbe implements Callable<Boolean> {
             String fail = " [FAIL]";
 
             log.info("[movedir] " +  srcDir.getClass().getSimpleName() + " " + srcDir.getUri() + " " + owner);
-            pth = NodeUtil.create(root, srcDir, group);
+            pth = NodeUtil.create(root, srcDir);
             if (pth == null || !Files.isDirectory(pth)) {
                 log.error("[movedir] failed to create directory in fs: " + root + "/" + srcDir.getUri() + fail);
                 return false;
             }
 
             log.info("[movedir] " +  destDir.getClass().getSimpleName() + " " + destDir.getUri() + " " + owner);
-            pth = NodeUtil.create(root, destDir, group);
+            pth = NodeUtil.create(root, destDir);
             if (pth == null || !Files.isDirectory(pth)) {
                 log.error("[movedir] failed to create directory in fs: " + root + "/" + destDir.getUri() + fail);
                 return false;
             }
 
             log.info("[movedir] " +  dn.getClass().getSimpleName() + " " + dn.getUri() + " " + owner);
-            pth = NodeUtil.create(root, dn, group);
+            pth = NodeUtil.create(root, dn);
             if (pth == null || !Files.exists(pth)) {
                 log.error("[movedir] failed to create file in fs: " + root + "/" + dn.getUri() + fail);
                 return false;
             }
 
             int num = 0;
-            NodeUtil.move(root, srcDir.getUri(), destDir.getUri(), owner, group);
+            NodeUtil.move(root, srcDir.getUri(), destDir.getUri(), owner);
             VOSURI expected = new VOSURI(URI.create("vos://canfar.net~cavern/" + name2 + "/" + name1 + "/" + name3));
             Node moved = NodeUtil.get(root, expected);
             if (moved == null || !(moved instanceof DataNode)) {
@@ -660,35 +658,35 @@ public class FileSystemProbe implements Callable<Boolean> {
             String fail = " [FAIL]";
 
             log.info("[copysymlink] " +  srcDir.getClass().getSimpleName() + " " + srcDir.getUri() + " " + owner);
-            pth = NodeUtil.create(root, srcDir, group);
+            pth = NodeUtil.create(root, srcDir);
             if (pth == null || !Files.isDirectory(pth)) {
                 log.error("[copysymlink] failed to create directory in fs: " + root + "/" + srcDir.getUri() + fail);
                 return false;
             }
 
             log.info("[copysymlink] " +  destDir.getClass().getSimpleName() + " " + destDir.getUri() + " " + owner);
-            pth = NodeUtil.create(root, destDir, group);
+            pth = NodeUtil.create(root, destDir);
             if (pth == null || !Files.isDirectory(pth)) {
                 log.error("[copysymlink] failed to create directory in fs: " + root + "/" + destDir.getUri() + fail);
                 return false;
             }
 
             log.info("[copysymlink] " +  dn.getClass().getSimpleName() + " " + dn.getUri() + " " + owner);
-            pth = NodeUtil.create(root, dn, group);
+            pth = NodeUtil.create(root, dn);
             if (pth == null || !Files.exists(pth)) {
                 log.error("[copysymlink] failed to create file in fs: " + root + "/" + dn.getUri() + fail);
                 return false;
             }
 
             log.info("[copysymlink] " +  ln.getClass().getSimpleName() + " " + ln.getUri() + " " + owner);
-            pth = NodeUtil.create(root, ln, group);
+            pth = NodeUtil.create(root, ln);
             if (pth == null || !Files.exists(pth)) {
                 log.error("[copysymlink] failed to create symlink in fs: " + root + "/" + ln.getUri() + fail);
                 return false;
             }
 
             int num = 0;
-            NodeUtil.copy(root, ln.getUri(), destDir.getUri(), owner, group);
+            NodeUtil.copy(root, ln.getUri(), destDir.getUri(), owner);
             VOSURI expected = new VOSURI(URI.create("vos://canfar.net~cavern/" + name2 + "/" + name4));
             Node copied = NodeUtil.get(root, expected);
             if (copied == null || !(copied instanceof DataNode)) {
@@ -745,35 +743,35 @@ public class FileSystemProbe implements Callable<Boolean> {
             String fail = " [FAIL]";
 
             log.info("[movesymlink] " +  srcDir.getClass().getSimpleName() + " " + srcDir.getUri() + " " + owner);
-            pth = NodeUtil.create(root, srcDir, group);
+            pth = NodeUtil.create(root, srcDir);
             if (pth == null || !Files.isDirectory(pth)) {
                 log.error("[movesymlink] failed to create directory in fs: " + root + "/" + srcDir.getUri() + fail);
                 return false;
             }
 
             log.info("[movesymlink] " +  destDir.getClass().getSimpleName() + " " + destDir.getUri() + " " + owner);
-            pth = NodeUtil.create(root, destDir, group);
+            pth = NodeUtil.create(root, destDir);
             if (pth == null || !Files.isDirectory(pth)) {
                 log.error("[movesymlink] failed to create directory in fs: " + root + "/" + destDir.getUri() + fail);
                 return false;
             }
 
             log.info("[movesymlink] " +  dn.getClass().getSimpleName() + " " + dn.getUri() + " " + owner);
-            pth = NodeUtil.create(root, dn, group);
+            pth = NodeUtil.create(root, dn);
             if (pth == null || !Files.exists(pth)) {
                 log.error("[movesymlink] failed to create file in fs: " + root + "/" + dn.getUri() + fail);
                 return false;
             }
 
             log.info("[movesymlink] " +  ln.getClass().getSimpleName() + " " + ln.getUri() + " " + owner);
-            pth = NodeUtil.create(root, ln, group);
+            pth = NodeUtil.create(root, ln);
             if (pth == null || !Files.exists(pth)) {
                 log.error("[movesymlink] failed to create symlink in fs: " + root + "/" + ln.getUri() + fail);
                 return false;
             }
 
             int num = 0;
-            NodeUtil.move(root, ln.getUri(), destDir.getUri(), owner, group);
+            NodeUtil.move(root, ln.getUri(), destDir.getUri(), owner);
             VOSURI expected = new VOSURI(URI.create("vos://canfar.net~cavern/" + name2 + "/" + name4));
             Node copied = NodeUtil.get(root, expected);
             if (copied == null || !(copied instanceof LinkNode)) {

--- a/cavern/src/main/java/org/opencadc/cavern/probe/Main.java
+++ b/cavern/src/main/java/org/opencadc/cavern/probe/Main.java
@@ -93,7 +93,6 @@ public class Main {
         System.out.println("usage: cavern [-v|--verbose|-d|--debug]");
         System.out.println("              --dir=<test directory>");
         System.out.println("              --owner=<posix username> ");
-        System.out.println("              --group=<posix group name>");
         System.out.println("              --target-owner=<posix username>)");
         System.out.println("Note: the target-owner owns the target of a link and should differ from");
         System.out.println("      the owner so that correct behaviour of symlinks can be verified");
@@ -135,10 +134,6 @@ public class Main {
                 log.error("missing required argument: --target-owner=<posix username>");
                 ok = false;
             }
-            if (group == null) {
-                log.error("missing required argument: --group=<posix group name>");
-                ok = false;
-            }
 
             File baseDir = null;
             if (dir != null) {
@@ -161,7 +156,7 @@ public class Main {
                 System.exit(1);
             }
 
-            FileSystemProbe probe = new FileSystemProbe(baseDir, owner, targetOwner, group);
+            FileSystemProbe probe = new FileSystemProbe(baseDir, owner, targetOwner);
             Boolean success = probe.call();
             if (success == null || !success) {
                 System.exit(1);

--- a/cavern/src/test/java/org/opencadc/cavern/PosixIdentityManagerTest.java
+++ b/cavern/src/test/java/org/opencadc/cavern/PosixIdentityManagerTest.java
@@ -104,7 +104,7 @@ public class PosixIdentityManagerTest {
     }
 
     private UserPrincipal getTestPrincipal() throws IOException {
-        return users.lookupPrincipalByName("guest");
+        return users.lookupPrincipalByName(System.getProperty("user.name"));
     }
 
     @Test

--- a/cavern/src/test/java/org/opencadc/cavern/nodes/NodeUtilTest.java
+++ b/cavern/src/test/java/org/opencadc/cavern/nodes/NodeUtilTest.java
@@ -106,7 +106,6 @@ public class NodeUtilTest {
     static final String ROOT = System.getProperty("java.io.tmpdir") + "/cavern-tests";
 
     static final String OWNER = System.getProperty("user.name");
-    static final String GROUP = System.getProperty("user.name");
 
     static {
         try {
@@ -123,8 +122,7 @@ public class NodeUtilTest {
     }
 
     private Path doCreate(final Path root, final Node n, UserPrincipal up) throws Exception {
-        GroupPrincipal gp = root.getFileSystem().getUserPrincipalLookupService().lookupPrincipalByGroupName(GROUP);
-        Path actual = NodeUtil.create(root, n, gp);
+        Path actual = NodeUtil.create(root, n);
 
         Assert.assertNotNull(actual);
         Assert.assertTrue("exists", Files.exists(actual, LinkOption.NOFOLLOW_LINKS));
@@ -425,8 +423,7 @@ public class NodeUtilTest {
 
             // move the data node to dir2
             log.debug("Moving: " + tn2.getUri() + " to " + testDir2);
-            GroupPrincipal gp = root.getFileSystem().getUserPrincipalLookupService().lookupPrincipalByGroupName(GROUP);
-            NodeUtil.move(root, tn.getUri(), testDir2, up, gp);
+            NodeUtil.move(root, tn.getUri(), testDir2, up);
             uri = new VOSURI(URI.create(testDir2.getURI().toASCIIString() + "/file-" + name));
             log.debug("Asserting: " + uri);
             Node moved = NodeUtil.get(root, uri);
@@ -439,7 +436,7 @@ public class NodeUtilTest {
 
             // move dir2 to dir1
             log.debug("Moving: " + testDir2 + " to " + dir);
-            NodeUtil.move(root, testDir2, testDir, up, gp);
+            NodeUtil.move(root, testDir2, testDir, up);
             uri = new VOSURI(URI.create(testDir.getURI().toASCIIString() + "/test-" + name2));
             log.debug("Asserting: " + uri);
             moved = NodeUtil.get(root, uri);
@@ -501,8 +498,7 @@ public class NodeUtilTest {
 
             // copy the data node to dir2
             log.debug("Copying: " + tn2.getUri() + " to " + testDir2);
-            GroupPrincipal gp = root.getFileSystem().getUserPrincipalLookupService().lookupPrincipalByGroupName(GROUP);
-            NodeUtil.copy(root, tn.getUri(), testDir2, up, gp);
+            NodeUtil.copy(root, tn.getUri(), testDir2, up);
             uri = new VOSURI(URI.create(testDir2.getURI().toASCIIString() + "/file-" + name));
             log.debug("Asserting: " + uri);
             Node copied = NodeUtil.get(root, uri);
@@ -578,8 +574,7 @@ public class NodeUtilTest {
             }
 
             log.debug("Copying: " + top + " to " + testDir2);
-            GroupPrincipal gp = root.getFileSystem().getUserPrincipalLookupService().lookupPrincipalByGroupName(GROUP);
-            NodeUtil.copy(root, top, testDir2, up, gp);
+            NodeUtil.copy(root, top, testDir2, up);
 
             // assert both copies are there
             for (VOSURI u : vosuris) {
@@ -680,8 +675,7 @@ public class NodeUtilTest {
             }
 
             log.debug("Copying: " + top + " to " + testDir2);
-            GroupPrincipal gp = root.getFileSystem().getUserPrincipalLookupService().lookupPrincipalByGroupName(GROUP);
-            NodeUtil.copy(root, top, testDir2, up, gp);
+            NodeUtil.copy(root, top, testDir2, up);
 
             // assert both copies are there
             for (VOSURI u : vosuris) {


### PR DESCRIPTION
Using the posix group with rwx to give cavern service full permissions on files also does one of:

- gives all users full permissions to those files (users belong to standard group)
- users can create files via mount that cavern service cannot manipulate (users do not belong to standard group so cannot chgrp)

Basically, the concept is not workable; cavern will need full permissions to the content tree via some other mechanism like ACLs