### PR TITLE
Story 2346. Added RUNID node property.

### DIFF
--- a/cadc-vos/build.gradle
+++ b/cadc-vos/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.1.3'
+version = '1.1.4'
 
 mainClassName = 'ca.nrc.cadc.vos.client.Main'
 

--- a/cadc-vos/src/main/java/ca/nrc/cadc/vos/VOS.java
+++ b/cadc-vos/src/main/java/ca/nrc/cadc/vos/VOS.java
@@ -235,7 +235,7 @@ public class VOS
      * Standard Node Properties defined by the CADC
      */
 
-    // Pass information to the service, e.g. runid = "TEST" means the service call is a test
+    // Property used for identifying a transaction"
     public static final String PROPERTY_URI_RUNID = "ivo://ivoa.net/vospace/core#runid";
 
     // The size of the resource

--- a/cadc-vos/src/main/java/ca/nrc/cadc/vos/VOS.java
+++ b/cadc-vos/src/main/java/ca/nrc/cadc/vos/VOS.java
@@ -235,6 +235,9 @@ public class VOS
      * Standard Node Properties defined by the CADC
      */
 
+    // Pass information to the service, e.g. runid = "TEST" means the service call is a test
+    public static final String PROPERTY_URI_RUNID = "ivo://ivoa.net/vospace/core#runid";
+
     // The size of the resource
     public static final String PROPERTY_URI_CONTENTLENGTH = "ivo://ivoa.net/vospace/core#length";
 


### PR DESCRIPTION
This node property is used by DOI. When a DOI web service creates a DOI, it adds this property to the DOI container node the parameter 'runId="TEST"' is present.