### PR TITLE
s2346, ta 10892: fix HttpPost usage in vospace client to use FileContent object…

### DIFF
--- a/cadc-vos/build.gradle
+++ b/cadc-vos/build.gradle
@@ -18,7 +18,7 @@ group = 'org.opencadc'
 version = '1.1.5'
 
 mainClassName = 'ca.nrc.cadc.vos.client.Main'
-
+  
 dependencies {
     compile 'log4j:log4j:1.2.+'
     compile 'org.jdom:jdom2:2.+'

--- a/cadc-vos/build.gradle
+++ b/cadc-vos/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.1.5'
+version = '1.1.6'
 
 mainClassName = 'ca.nrc.cadc.vos.client.Main'
   

--- a/cadc-vos/build.gradle
+++ b/cadc-vos/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.1.4'
+version = '1.1.5'
 
 mainClassName = 'ca.nrc.cadc.vos.client.Main'
 
@@ -25,7 +25,7 @@ dependencies {
     compile 'xerces:xercesImpl:2.+'
     compile 'org.json:json:20160212'
 
-    compile 'org.opencadc:cadc-util:[1.2.0,)'
+    compile 'org.opencadc:cadc-util:[1.2.8,)'
     compile 'org.opencadc:cadc-uws:1.+'
     compile 'org.opencadc:cadc-registry:1.+'
 

--- a/cadc-vos/src/main/java/ca/nrc/cadc/vos/client/VOSpaceClient.java
+++ b/cadc-vos/src/main/java/ca/nrc/cadc/vos/client/VOSpaceClient.java
@@ -69,6 +69,7 @@
 
 package ca.nrc.cadc.vos.client;
 
+import ca.nrc.cadc.net.FileContent;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -77,6 +78,7 @@ import java.io.Writer;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.security.AccessControlException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -90,8 +92,6 @@ import org.apache.log4j.Logger;
 
 import ca.nrc.cadc.auth.AuthMethod;
 import ca.nrc.cadc.auth.AuthenticationUtil;
-import ca.nrc.cadc.auth.SSOCookieCredential;
-import ca.nrc.cadc.auth.X509CertificateChain;
 import ca.nrc.cadc.net.HttpDelete;
 import ca.nrc.cadc.net.HttpDownload;
 import ca.nrc.cadc.net.HttpPost;
@@ -336,7 +336,8 @@ public class VOSpaceClient
             NodeWriter nodeWriter = new NodeWriter();
             StringBuilder nodeXML = new StringBuilder();
             nodeWriter.write(node, nodeXML);
-            HttpPost httpPost = new HttpPost(url, nodeXML.toString(), null, false);
+            FileContent nodeContent = new FileContent(nodeXML.toString(), "text/xml", Charset.forName("UTF-8"));
+            HttpPost httpPost = new HttpPost(url, nodeContent, false);
 
             httpPost.run();
 
@@ -375,7 +376,8 @@ public class VOSpaceClient
             nodeWriter.write(node, stringWriter);
 //            URL postUrl = new URL(asyncNodePropsUrl);
 
-            HttpPost httpPost = new HttpPost(vospaceURL, stringWriter.toString(), "text/xml", false);
+            FileContent nodeContent = new FileContent(stringWriter.toString(), "text/xml", Charset.forName("UTF-8"));
+            HttpPost httpPost = new HttpPost(vospaceURL, nodeContent, false);
 
             httpPost.run();
 
@@ -499,7 +501,8 @@ public class VOSpaceClient
             Writer stringWriter = new StringWriter();
             transferWriter.write(transfer, stringWriter);
 
-            HttpPost httpPost = new HttpPost(vospaceURL, stringWriter.toString(), "text/xml", false);
+            FileContent transferContent = new FileContent(stringWriter.toString(), "text/xml", Charset.forName("UTF-8"));
+            HttpPost httpPost = new HttpPost(vospaceURL, transferContent, false);
 
             httpPost.run();
 
@@ -558,7 +561,8 @@ public class VOSpaceClient
                 StringWriter sw = new StringWriter();
                 writer.write(transfer, sw);
 
-                httpPost = new HttpPost(vospaceURL, sw.toString(), "text/xml", false);
+                FileContent transferContent = new FileContent(sw.toString(), "text/xml", Charset.forName("UTF-8"));
+                httpPost = new HttpPost(vospaceURL, transferContent, false);
             }
 
             httpPost.run();


### PR DESCRIPTION
…, consistent with new direction for this service, to support (and requires!)  changes made in cadc-util 1.1.8