### PR TITLE
Link targets to local vospace nodes saved as absolute paths

### DIFF
--- a/cadc-vos-server/build.gradle
+++ b/cadc-vos-server/build.gradle
@@ -14,7 +14,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.1.3'
+version = '1.1.4'
 
 dependencies {
     compile 'log4j:log4j:1.2.+'

--- a/cadc-vos-server/src/main/java/ca/nrc/cadc/vos/server/NodeDAO.java
+++ b/cadc-vos-server/src/main/java/ca/nrc/cadc/vos/server/NodeDAO.java
@@ -2723,7 +2723,8 @@ public class NodeDAO
             pval = null;
             if (node instanceof LinkNode)
             {
-                pval = ((LinkNode)node).getTarget().toString();
+                URI targetURI = ((LinkNode)node).getTarget();
+                pval = NodeMapper.createDBLinkString(targetURI, authority);
                 ps.setString(col, pval);
             }
             else
@@ -3030,14 +3031,7 @@ public class NodeDAO
 	            }
 	            else if (NODE_TYPE_LINK.equals(type))
 	            {
-	                URI link;
-
-	                try { link = new URI(linkStr); }
-	                catch(URISyntaxException bug)
-	                {
-	                    throw new RuntimeException("BUG - failed to create link URI", bug);
-	                }
-
+	                URI link = NodeMapper.extractLinkURI(linkStr, authority);
 	                node = new LinkNode(vos, link);
 	            }
 	            else

--- a/cadc-vos-server/src/main/java/ca/nrc/cadc/vos/server/NodeMapper.java
+++ b/cadc-vos-server/src/main/java/ca/nrc/cadc/vos/server/NodeMapper.java
@@ -3,7 +3,7 @@
 *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 *
-*  (c) 2009.                            (c) 2009.
+*  (c) 2019.                            (c) 2019.
 *  Government of Canada                 Gouvernement du Canada
 *  National Research Council            Conseil national de recherches
 *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -98,6 +98,8 @@ public class NodeMapper implements RowMapper
 {
     private static Logger log = Logger.getLogger(NodeMapper.class);
     
+    private static final String ABSOLUTE_LINK_SCHEME = "abs:";
+    
     private DateFormat dateFormat;
     private Calendar cal;
 
@@ -170,11 +172,8 @@ public class NodeMapper implements RowMapper
         else if (NodeDAO.NODE_TYPE_LINK.equals(type))
         {
             link = rs.getString("link");
-            try { node = new LinkNode(vos, new URI(link)); }
-            catch(URISyntaxException bug)
-            {
-                throw new RuntimeException("BUG - failed to create link URI", bug);
-            }
+            URI linkURI = extractLinkURI(link, authority);
+            node = new LinkNode(vos, linkURI);
         }
         else
         {
@@ -243,6 +242,60 @@ public class NodeMapper implements RowMapper
         }
         log.debug("read: " + node.getUri() + "," + node.appData);
         return node;
+    }
+    
+    /**
+     * Transform a link from the DB for the API.  Absolute links
+     * will be restored as full VOS links with the current authority.
+     * 
+     * @param link
+     * @param authority
+     * @return
+     */
+    static URI extractLinkURI(String link, String authority) {
+        try {
+            if (link == null) {
+                throw new RuntimeException("Null link URI");
+            }
+            URI linkURI = null;
+            if (link.startsWith(ABSOLUTE_LINK_SCHEME)) {
+                // translate it to a VOS URI with the local authority
+                URI absURI = new URI(link);
+                linkURI = new URI(VOSURI.SCHEME, authority, absURI.getPath(),
+                    absURI.getQuery(), absURI.getFragment());
+            } else {
+                linkURI = new URI(link);
+            }
+            return linkURI;
+        } catch (URISyntaxException bug) {
+            throw new RuntimeException("BUG - failed to create link URI", bug);
+        }
+    }
+    
+    /**
+     * Transform a link URI for db persistence.  Local vos URIs will
+     * be changed to absolute path links.
+     * 
+     * @param link
+     * @param authority
+     * @return
+     */
+    static String createDBLinkString(URI link, String authority) {
+        if (link == null) {
+            return null;
+        }
+        if (link.getScheme() != null && link.getScheme().equals(VOSURI.SCHEME) &&
+                link.getAuthority().equals(authority)) {
+            String dbURI = ABSOLUTE_LINK_SCHEME + link.getPath();
+            if (link.getQuery() != null) {
+                dbURI += "?" + link.getQuery();
+            }
+            if (link.getFragment() != null) {
+                dbURI += "#" + link.getFragment();
+            }
+            return dbURI;
+        }
+        return link.toASCIIString();   
     }
 
 }

--- a/cadc-vos-server/src/test/java/ca/nrc/cadc/vos/server/NodeMapperTest.java
+++ b/cadc-vos-server/src/test/java/ca/nrc/cadc/vos/server/NodeMapperTest.java
@@ -158,6 +158,9 @@ public class NodeMapperTest {
             inURI = new VOSURI("vos://different.authority~vospace/path/to/file").getURI();
             Assert.assertEquals(inURI, NodeMapper.extractLinkURI(inURI.toString(), authority));
             
+            inURI = new URI("http://mysite.com?query=string#fragment");
+            Assert.assertEquals(inURI, NodeMapper.extractLinkURI(inURI.toString(), authority));
+            
         } catch (Throwable t) {
          
             log.error("Unexpected error", t);

--- a/cadc-vos-server/src/test/java/ca/nrc/cadc/vos/server/NodeMapperTest.java
+++ b/cadc-vos-server/src/test/java/ca/nrc/cadc/vos/server/NodeMapperTest.java
@@ -145,5 +145,24 @@ public class NodeMapperTest {
             Assert.fail("unexpected: " + t.getMessage());
         }
     }
+    
+    @Test
+    public void testBackwardsCompat() {
+        
+        try {
+            
+            String authority = null;
+            URI inURI = null;
+            
+            authority = "cadc.nrc.ca~vospace";
+            inURI = new VOSURI("vos://different.authority~vospace/path/to/file").getURI();
+            Assert.assertEquals(inURI, NodeMapper.extractLinkURI(inURI.toString(), authority));
+            
+        } catch (Throwable t) {
+         
+            log.error("Unexpected error", t);
+            Assert.fail("unexpected: " + t.getMessage());
+        }
+    }
 
 }

--- a/cadc-vos-server/src/test/java/ca/nrc/cadc/vos/server/NodeMapperTest.java
+++ b/cadc-vos-server/src/test/java/ca/nrc/cadc/vos/server/NodeMapperTest.java
@@ -1,0 +1,149 @@
+/*
+************************************************************************
+*******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+**************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+*
+*  (c) 2019.                            (c) 2019.
+*  Government of Canada                 Gouvernement du Canada
+*  National Research Council            Conseil national de recherches
+*  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+*  All rights reserved                  Tous droits réservés
+*
+*  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+*  expressed, implied, or               énoncée, implicite ou légale,
+*  statutory, of any kind with          de quelque nature que ce
+*  respect to the software,             soit, concernant le logiciel,
+*  including without limitation         y compris sans restriction
+*  any warranty of merchantability      toute garantie de valeur
+*  or fitness for a particular          marchande ou de pertinence
+*  purpose. NRC shall not be            pour un usage particulier.
+*  liable in any event for any          Le CNRC ne pourra en aucun cas
+*  damages, whether direct or           être tenu responsable de tout
+*  indirect, special or general,        dommage, direct ou indirect,
+*  consequential or incidental,         particulier ou général,
+*  arising from the use of the          accessoire ou fortuit, résultant
+*  software.  Neither the name          de l'utilisation du logiciel. Ni
+*  of the National Research             le nom du Conseil National de
+*  Council of Canada nor the            Recherches du Canada ni les noms
+*  names of its contributors may        de ses  participants ne peuvent
+*  be used to endorse or promote        être utilisés pour approuver ou
+*  products derived from this           promouvoir les produits dérivés
+*  software without specific prior      de ce logiciel sans autorisation
+*  written permission.                  préalable et particulière
+*                                       par écrit.
+*
+*  This file is part of the             Ce fichier fait partie du projet
+*  OpenCADC project.                    OpenCADC.
+*
+*  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+*  you can redistribute it and/or       vous pouvez le redistribuer ou le
+*  modify it under the terms of         modifier suivant les termes de
+*  the GNU Affero General Public        la “GNU Affero General Public
+*  License as published by the          License” telle que publiée
+*  Free Software Foundation,            par la Free Software Foundation
+*  either version 3 of the              : soit la version 3 de cette
+*  License, or (at your option)         licence, soit (à votre gré)
+*  any later version.                   toute version ultérieure.
+*
+*  OpenCADC is distributed in the       OpenCADC est distribué
+*  hope that it will be useful,         dans l’espoir qu’il vous
+*  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+*  without even the implied             GARANTIE : sans même la garantie
+*  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+*  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+*  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+*  General Public License for           Générale Publique GNU Affero
+*  more details.                        pour plus de détails.
+*
+*  You should have received             Vous devriez avoir reçu une
+*  a copy of the GNU Affero             copie de la Licence Générale
+*  General Public License along         Publique GNU Affero avec
+*  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+*  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+*                                       <http://www.gnu.org/licenses/>.
+*
+*  $Revision: 4 $
+*
+************************************************************************
+*/
+
+package ca.nrc.cadc.vos.server;
+
+import java.net.URI;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.junit.Assert;
+import org.junit.Test;
+
+import ca.nrc.cadc.util.Log4jInit;
+import ca.nrc.cadc.vos.VOSURI;
+
+public class NodeMapperTest {
+    
+    private static Logger log = Logger.getLogger(NodeMapperTest.class);
+    static
+    {
+        Log4jInit.setLevel("ca.nrc.cadc.vos.server", Level.INFO);
+    }
+    
+    @Test
+    public void testAbsoluteLinkURI() {
+        
+        try {
+            
+            String authority = null;
+            URI inURI = null;
+            String dbLink = null;
+            
+            authority = "cadc.nrc.ca~vospace";
+            inURI = new VOSURI("vos://" + authority + "/path/to/file").getURI();
+            dbLink = NodeMapper.createDBLinkString(inURI, authority);
+            Assert.assertEquals(inURI, NodeMapper.extractLinkURI(dbLink, authority));
+            
+            authority = "cadc.nrc.ca!vospace";
+            inURI = new VOSURI("vos://" + authority + "/path/to/file").getURI();
+            dbLink = NodeMapper.createDBLinkString(inURI, authority);
+            Assert.assertEquals(inURI, NodeMapper.extractLinkURI(dbLink, authority));
+            
+            authority = "cadc.nrc.ca~vospace";
+            inURI = new VOSURI("vos://" + authority + "/path/to/file").getURI();
+            dbLink = NodeMapper.createDBLinkString(inURI, authority);
+            authority = "canfar.net~vault";
+            inURI = new VOSURI("vos://" + authority + "/path/to/file").getURI();
+            Assert.assertEquals(inURI, NodeMapper.extractLinkURI(dbLink, authority));
+            
+        } catch (Throwable t) {
+         
+            log.error("Unexpected error", t);
+            Assert.fail("unexpected: " + t.getMessage());
+        }
+    }
+    
+    @Test
+    public void testExternalLinkURI() {
+        
+        try {
+            
+            String authority = null;
+            URI inURI = null;
+            String dbLink = null;
+            
+            authority = "cadc.nrc.ca~vospace";
+            inURI = new VOSURI("vos://different.authority~vospace/path/to/file").getURI();
+            dbLink = NodeMapper.createDBLinkString(inURI, authority);
+            Assert.assertEquals(inURI, NodeMapper.extractLinkURI(dbLink, authority));
+            
+            authority = "cadc.nrc.ca!vospace";
+            inURI = new URI("https://externalurl:8080/path/to/file?query=param#frag");
+            dbLink = NodeMapper.createDBLinkString(inURI, authority);
+            Assert.assertEquals(inURI, NodeMapper.extractLinkURI(dbLink, authority));
+            
+        } catch (Throwable t) {
+         
+            log.error("Unexpected error", t);
+            Assert.fail("unexpected: " + t.getMessage());
+        }
+    }
+
+}


### PR DESCRIPTION
This change is to decouple VOS URIs (which contain the authority and serviceID) from the database persistence so that implementors may easily change authorities and serviceIDs.