### PR TITLE
CADC-11650, 11671, 11672, 11678 - adding cavern/preauth and new access to cavern/files

### DIFF
--- a/cadc-vos-server/build.gradle
+++ b/cadc-vos-server/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     compile 'org.restlet.jse:org.restlet:2.0.2'
     compile 'org.springframework:spring-jdbc:5.2.9.RELEASE'
 
-    compile 'org.opencadc:cadc-util:[1.6,2.0)'
+    compile 'org.opencadc:cadc-util:[1.6.7,2.0)'
     compile 'org.opencadc:cadc-gms:[1.0.0,)'
     compile 'org.opencadc:cadc-vos:[1.2.1,)'
     compile 'org.opencadc:cadc-vosi:[1.3.2,)'

--- a/cavern/VERSION
+++ b/cavern/VERSION
@@ -1,4 +1,4 @@
 ## deployable containers have a semantic and build tag
 # semantic version tag: major.minor
 # build version tag: timestamp
-TAGS="0.4.1 $(date -u +"%Y%m%dT%H%M%S")"
+TAGS="0.4.2 $(date -u +"%Y%m%dT%H%M%S")"

--- a/cavern/build.gradle
+++ b/cavern/build.gradle
@@ -50,8 +50,9 @@ dependencies {
     compile 'xerces:xercesImpl:[2.0,)'
     compile 'commons-net:commons-net:[2.0,)'
 
-    compile 'org.opencadc:cadc-util:[1.6,)'
+    compile 'org.opencadc:cadc-util:[1.6.5,)'
     compile 'org.opencadc:cadc-log:[1.0,)'
+    compile 'org.opencadc:cadc-permissions:[0.3.3,)'
     compile 'org.opencadc:cadc-registry:[1.5.9,)'
     compile 'org.opencadc:cadc-vosi:[1.4.3,)'
     compile 'org.opencadc:cadc-rest:[1.3.5,)'

--- a/cavern/src/intTest/java/org/opencadc/cavern/DefaultACLPermissionsTest.java
+++ b/cavern/src/intTest/java/org/opencadc/cavern/DefaultACLPermissionsTest.java
@@ -118,7 +118,7 @@ public class DefaultACLPermissionsTest {
     static {
         Log4jInit.setLevel("org.opencadc.cavern", Level.DEBUG);
         Log4jInit.setLevel("ca.nrc.cadc.vospace", Level.INFO);
-        Log4jInit.setLevel("ca.nrc.cadc.vos", Level.INFO);
+        Log4jInit.setLevel("ca.nrc.cadc.vos", Level.DEBUG);
         Log4jInit.setLevel("ca.nrc.cadc.net", Level.DEBUG);
     }
 

--- a/cavern/src/intTest/java/org/opencadc/cavern/MetadataIntTest.java
+++ b/cavern/src/intTest/java/org/opencadc/cavern/MetadataIntTest.java
@@ -110,8 +110,11 @@ public class MetadataIntTest {
     private static VOSURI linksBaseURI;
 
     static {
-        Log4jInit.setLevel("org.opencadc.cavern", Level.INFO);
-        Log4jInit.setLevel("ca.nrc.cadc.vos", Level.INFO);
+        Log4jInit.setLevel("org.opencadc.cavern", Level.DEBUG);
+        Log4jInit.setLevel("ca.nrc.cadc.vos", Level.DEBUG);
+        Log4jInit.setLevel("ca.nrc.cadc.vospace", Level.DEBUG);
+        Log4jInit.setLevel("ca.nrc.cadc.vos.client", Level.DEBUG);
+        Log4jInit.setLevel("ca.nrc.cadc.net", Level.DEBUG);
     }
 
     public MetadataIntTest() {

--- a/cavern/src/intTest/java/org/opencadc/cavern/MountedContainerTest.java
+++ b/cavern/src/intTest/java/org/opencadc/cavern/MountedContainerTest.java
@@ -224,19 +224,23 @@ public class MountedContainerTest {
         String[] cmd = getMountCommand(wrapper, port, mnt, testDir);
         StringBuilder sb = new StringBuilder();
         for (String s : cmd) {
+            log.info("command: " + s);
             sb.append(s).append(" ");
         }
         log.info("mount command: " + sb.toString());
         BuilderOutputGrabber grabber = new BuilderOutputGrabber();
         grabber.captureOutput(cmd);
+        log.info("exit code from grabber for cmd: " + grabber.getExitValue());
         if (grabber.getExitValue() != 0) {
             throw new IOException("FAIL: " + sb + "\n" + grabber.getErrorOutput());
-        } 
+        }
+
     }
     
     private void doUnmount(Path testDir) throws Exception {
         String[] cmd = getUnmountCommand(testDir);
         BuilderOutputGrabber grabber = new BuilderOutputGrabber();
+
         grabber.captureOutput(cmd);
         if (grabber.getExitValue() != 0) {
             StringBuilder sb = new StringBuilder();

--- a/cavern/src/intTest/java/org/opencadc/cavern/TransferRunnerTest.java
+++ b/cavern/src/intTest/java/org/opencadc/cavern/TransferRunnerTest.java
@@ -122,8 +122,9 @@ public class TransferRunnerTest {
 
     static {
         Log4jInit.setLevel("org.opencadc.cavern", Level.DEBUG);
-        Log4jInit.setLevel("ca.nrc.cadc.vospace", Level.DEBUG);
+        Log4jInit.setLevel("ca.nrc.cadc.vospace", Level.INFO);
         Log4jInit.setLevel("ca.nrc.cadc.vos", Level.DEBUG);
+        Log4jInit.setLevel("ca.nrc.cadc.rest", Level.DEBUG);
     }
 
     public TransferRunnerTest() {

--- a/cavern/src/main/java/org/opencadc/cavern/files/CavernURLGenerator.java
+++ b/cavern/src/main/java/org/opencadc/cavern/files/CavernURLGenerator.java
@@ -67,6 +67,7 @@
 
 package org.opencadc.cavern.files;
 
+
 import ca.nrc.cadc.auth.AuthenticationUtil;
 import ca.nrc.cadc.net.ResourceNotFoundException;
 import ca.nrc.cadc.net.TransientException;
@@ -75,9 +76,9 @@ import ca.nrc.cadc.reg.Capability;
 import ca.nrc.cadc.reg.Interface;
 import ca.nrc.cadc.reg.Standards;
 import ca.nrc.cadc.reg.client.RegistryClient;
+import ca.nrc.cadc.util.FileUtil;
 import ca.nrc.cadc.util.PropertiesReader;
-import ca.nrc.cadc.util.RsaSignatureGenerator;
-import ca.nrc.cadc.util.RsaSignatureVerifier;
+import ca.nrc.cadc.util.Base64;
 import ca.nrc.cadc.uws.Job;
 import ca.nrc.cadc.uws.Parameter;
 import ca.nrc.cadc.vos.ContainerNode;
@@ -91,9 +92,10 @@ import ca.nrc.cadc.vos.Transfer;
 import ca.nrc.cadc.vos.VOS;
 import ca.nrc.cadc.vos.VOSURI;
 import ca.nrc.cadc.vos.View;
+import ca.nrc.cadc.vos.server.LocalServiceURI;
 import ca.nrc.cadc.vos.server.PathResolver;
 import ca.nrc.cadc.vos.server.transfers.TransferGenerator;
-import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
@@ -103,18 +105,22 @@ import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.attribute.UserPrincipal;
 import java.security.AccessControlException;
-import java.security.InvalidKeyException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.MissingResourceException;
 import org.apache.log4j.Logger;
-import org.bouncycastle.util.encoders.Base64;
 import org.opencadc.cavern.FileSystemNodePersistence;
+import org.opencadc.permissions.Grant;
+import org.opencadc.permissions.ReadGrant;
+import org.opencadc.permissions.TokenTool;
+import org.opencadc.permissions.WriteGrant;
 
 public class CavernURLGenerator implements TransferGenerator {
 
     private static final Logger log = Logger.getLogger(CavernURLGenerator.class);
 
-    //private String root;
+    private static final String DEFAULT_CONFIG_DIR = System.getProperty("user.home") + "/config/";
+
     private final FileSystemNodePersistence nodes;
     private final String sshServerBase;
 
@@ -125,6 +131,7 @@ public class CavernURLGenerator implements TransferGenerator {
     
     private static final String PUB_KEY_FILENAME = "CavernPub.key";
     private static final String PRIV_KEY_FILENAME = "CavernPriv.key";
+    private static final String CAVERN_INTERNAL_USER = "cavernInternalUser";
 
     public CavernURLGenerator() {
         this.nodes = new FileSystemNodePersistence();
@@ -192,12 +199,18 @@ public class CavernURLGenerator implements TransferGenerator {
         }
     }
 
+
+
     private List<URI> handleDataNode(VOSURI target, DataNode node, Protocol protocol) {
         String scheme = null;
         Direction dir = null;
+
         try {
+            // Used in TokenTool.generateToken()
+            Class<? extends Grant> grantClass = null;
+
             switch (protocol.getUri()) {
-                /** 
+                /**
                  * HTTP not currently supported
                 case VOS.PROTOCOL_HTTP_GET:
                     scheme = "http";
@@ -211,56 +224,42 @@ public class CavernURLGenerator implements TransferGenerator {
                 case VOS.PROTOCOL_HTTPS_GET:
                     scheme = "https";
                     dir = Direction.pullFromVoSpace;
+                    grantClass = ReadGrant.class;
                     break;
                 case VOS.PROTOCOL_HTTPS_PUT:
                     scheme = "https";
                     dir = Direction.pushToVoSpace;
+                    grantClass = WriteGrant.class;
                     break;
-            }
+           }
 
             List<URL> baseURLs = getBaseURLs(target, protocol.getSecurityMethod(), scheme);
             if (baseURLs == null || baseURLs.isEmpty()) {
                 log.debug("no matching interfaces ");
                 return new ArrayList<URI>(0);
             }
-            
+
             if (dir == null) {
                 log.debug("no matching protocols");
                 return new ArrayList<URI>(0);
             }
 
-            // create the metadata and signature segments
-            StringBuilder metaSb = new StringBuilder();
-            metaSb.append(KEY_META_NODE).append("=").append(target.toString());
-            metaSb.append("&");
-            metaSb.append(KEY_META_DIRECTION).append("=").append(dir.getValue());
-            byte[] metaBytes = metaSb.toString().getBytes();
+            // Use TokenTool to generate a preauth token
+            File privateKeyFile = findFile(PRIV_KEY_FILENAME);
+            File pubKeyFile = findFile(PUB_KEY_FILENAME);
 
-            RsaSignatureGenerator sg = new RsaSignatureGenerator(PRIV_KEY_FILENAME);
-            String sig;
-            try {
-                byte[] sigBytes = sg.sign(new ByteArrayInputStream(metaBytes));
-                sig = new String(Base64.encode(sigBytes));
-                log.debug("Created signature: " + sig + " for meta: " + metaSb.toString());
-            } catch (InvalidKeyException | IOException | RuntimeException e) {
-                throw new IllegalStateException("Could not sign url", e);
-            }
-            String meta = new String(Base64.encode(metaBytes));
-            log.debug("meta: " + meta);
-            log.debug("sig: " + sig);
+            TokenTool gen = new TokenTool(pubKeyFile, privateKeyFile);
+
+            // Format of token is <base64 url encoded meta>.<base64 url encoded signature>
+            String token = gen.generateToken(target.getURI(), grantClass, CAVERN_INTERNAL_USER);
+            String encodedToken = new String(Base64.encode(token.getBytes()));
 
             // build the request path
             StringBuilder path = new StringBuilder();
-            String metaURLEncoded = base64URLEncode(meta);
-            String sigURLEncoded = base64URLEncode(sig);
-
-            log.debug("metaURLEncoded: " + metaURLEncoded);
-            log.debug("sigURLEncoded: " + sigURLEncoded);
-
             path.append("/");
-            path.append(metaURLEncoded);
+            path.append(encodedToken);
             path.append("/");
-            path.append(sigURLEncoded);
+
             if (Direction.pushToVoSpace.equals(dir)) {
                 // put to resolved path
                 path.append(node.getUri().getPath());
@@ -279,7 +278,7 @@ public class CavernURLGenerator implements TransferGenerator {
                     log.debug("Added url: " + next);
                     returnList.add(next);
                 } catch (URISyntaxException e) {
-                    throw new IllegalStateException("Could not generate trannsfer endpoint uri", e);
+                    throw new IllegalStateException("Could not generate transfer endpoint uri", e);
                 }
             }
 
@@ -308,78 +307,55 @@ public class CavernURLGenerator implements TransferGenerator {
         return ret;
     }
 
-    public VOSURI getNodeURI(String meta, String sig, Direction direction) throws AccessControlException, IOException {
+    public VOSURI getNodeURI(String token, VOSURI targetVOSURI, Direction direction) throws AccessControlException, IOException {
 
-        if (sig == null || meta == null) {
-            throw new IllegalArgumentException("Missing signature or meta info");
-        }
+        // TODO: behaviour will vary if token passed in or not
+        log.debug("url encoded token: " + token);
+        log.debug("direction: " + direction.toString());
 
-        log.debug("sig: " + sig);
-        log.debug("meta: " + meta);
+        String decodedTokenbytes = new String(Base64.decode(token));
+        log.debug("url decoded token: " + decodedTokenbytes);
 
-        byte[] sigBytes = Base64.decode(base64URLDecode(sig));
-        byte[] metaBytes = Base64.decode(base64URLDecode(meta));
+        URI targetURI = targetVOSURI.getURI();
+        URI nodeURI = null;
+        if (token != null) {
 
-        RsaSignatureVerifier sv = new RsaSignatureVerifier(PUB_KEY_FILENAME);
-        boolean verified;
-        try {
-            verified = sv.verify(new ByteArrayInputStream(metaBytes), sigBytes);
-        } catch (InvalidKeyException | RuntimeException e) {
-            log.debug("Recieved invalid signature", e);
-            throw new AccessControlException("Invalid signature");
-        }
-        if (!verified) {
-            throw new AccessControlException("Invalid signature");
-        }
+            File publicKeyFile = findFile(PUB_KEY_FILENAME);
+            TokenTool tk = new TokenTool(publicKeyFile);
 
-        String[] metaParams = new String(metaBytes).split("&");
-        String nodeURI = null;
-        String dir = null;
-        for (String metaParam : metaParams) {
-            log.debug("Processing param: " + metaParam);
-            String[] keyValue = metaParam.split("=");
-            if (keyValue.length == 2) {
-                if (KEY_META_NODE.equals(keyValue[0])) {
-                    nodeURI = keyValue[1];
-                }
-                if (KEY_META_DIRECTION.equals(keyValue[0])) {
-                    dir = keyValue[1];
-                }
+            Class<? extends Grant> grantClass = null;
+            if (Direction.pushToVoSpace.equals(direction)) {
+                grantClass = WriteGrant.class;
+            } else if (Direction.pullFromVoSpace.equals(direction)) {
+                grantClass = ReadGrant.class;
+            }
+
+            log.debug("grant class: " + grantClass);
+
+            // This will throw an AccessControlException if something is wrong with the
+            // grantClass or targetURI. Can return null if user isn't in the meta key=value set
+            String tokenUser = tk.validateToken(decodedTokenbytes, targetURI, grantClass);
+
+            if (tokenUser == null) {
+                throw new AccessControlException("invalid token");
+            }
+
+            if (CAVERN_INTERNAL_USER.equals(tokenUser)) {
+                nodeURI = targetURI;
+            } else {
+                throw new AccessControlException("Invalid user in token: " + tokenUser);
             }
         }
-        log.debug("nodeURI: " + nodeURI);
-        log.debug("dir: " + dir);
-        if (dir == null) {
-            throw new IllegalArgumentException("Direction not specified");
-        }
-        if (!direction.getValue().equals(dir)) {
-            throw new IllegalArgumentException("Wrong direction");
-        }
+
+        log.debug("nodeURI: " + nodeURI.toString());
+
         if (nodeURI != null) {
-            try {
-                VOSURI vosURI = new VOSURI(nodeURI);
-                return vosURI;
-            } catch (URISyntaxException e) {
-                throw new IllegalStateException("Invalid node URI");
-            }
+            VOSURI vosURI = new VOSURI(nodeURI);
+            log.debug("vosURI generated from node URI: " + vosURI);
+            return vosURI;
         }
 
         throw new IllegalArgumentException("Missing node URI");
-
-    }
-
-    public static String base64URLEncode(String s) {
-        if (s == null) {
-            return null;
-        }
-        return s.replace("/", "-").replace("+", "_");
-    }
-
-    public static String base64URLDecode(String s) {
-        if (s == null) {
-            return null;
-        }
-        return s.replace("-", "/").replace("_", "+");
     }
 
     List<URL> getBaseURLs(VOSURI target, URI securityMethod, String scheme) {
@@ -412,4 +388,37 @@ public class CavernURLGenerator implements TransferGenerator {
         return baseURLs;
     }
 
+    protected static final File findFile(String fname) throws MissingResourceException {
+        File ret = new File(DEFAULT_CONFIG_DIR, fname);
+        if (!ret.exists()) {
+            ret = FileUtil.getFileFromResource(fname, CavernURLGenerator.class);
+        }
+        return ret;
+    }
+
+
+    public static VOSURI getURIFromPath(String path) throws URISyntaxException {
+
+        log.debug("getURIFromPath for " + path);
+        LocalServiceURI localServiceURI = new LocalServiceURI();
+        VOSURI baseURI = localServiceURI.getVOSBase();
+        log.debug("baseURI for cavern deployment: " + baseURI.toString());
+
+        int firstSlashIndex = path.indexOf("/");
+        String pathStr = path.substring(firstSlashIndex + 1);
+        log.debug("path: " + pathStr);
+        String targetURIStr = baseURI.toString() + "/" + pathStr;
+        log.debug("target URI for validating token: " + targetURIStr);
+
+        URI targetURI = new URI(targetURIStr);
+        log.debug("targetURI for system: " + targetURI.toString());
+        VOSURI targetVOSURI = new VOSURI(targetURI);
+        log.debug("targetVOSURI: " + targetVOSURI.getURI().toString());
+
+        return targetVOSURI;
+
+    }
+
 }
+
+

--- a/cavern/src/main/java/org/opencadc/cavern/files/FileAction.java
+++ b/cavern/src/main/java/org/opencadc/cavern/files/FileAction.java
@@ -73,7 +73,10 @@ import ca.nrc.cadc.util.PropertiesReader;
 import ca.nrc.cadc.vos.Direction;
 import ca.nrc.cadc.vos.VOSURI;
 
+import ca.nrc.cadc.vos.server.LocalServiceURI;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.GroupPrincipal;
@@ -113,7 +116,7 @@ public abstract class FileAction extends RestAction {
         return null;
     }
 
-    protected VOSURI getNodeURI() throws AccessControlException, IOException {
+    protected VOSURI getNodeURI() throws AccessControlException, IOException, URISyntaxException {
         initTarget();
         return nodeURI;
     }
@@ -132,20 +135,40 @@ public abstract class FileAction extends RestAction {
 
     protected abstract Direction getDirection();
 
-    private void initTarget() throws AccessControlException, IOException {
+    private void initTarget() throws AccessControlException, IOException, URISyntaxException {
         if (nodeURI == null) {
             String path = syncInput.getPath();
+
+//            LocalServiceURI localServiceURI = new LocalServiceURI();
+//            VOSURI baseURI = localServiceURI.getVOSBase();
+//            log.debug("baseURI for target node: " + baseURI.toString());
+
             String[] parts = path.split("/");
-            if (parts.length < 3) {
+            if (parts.length < 2) {
                 throw new IllegalArgumentException("Invalid request");
             }
-            String meta = parts[0];
-            String sig = parts[1];
-            log.debug("meta: " + meta);
-            log.debug("sig: " + sig);
+//            String meta = parts[0];
+//            String sig = parts[1];
+//            log.debug("meta: " + meta);
+//            log.debug("sig: " + sig);
+            String token = parts[0];
+            log.debug("token: " + token);
+
+//            int firstSlashIndex = path.indexOf("/");
+//            String pathStr = path.substring(firstSlashIndex + 1);
+//            log.debug("path: " + pathStr);
+//            String targetURIStr = baseURI.toString() + "/" + pathStr;
+//            log.debug("target URI for validating token: " + targetURIStr);
+//            // TODO: could be that having an error trap here is better than just
+//            // throwing it in the signature
+//            URI targetURI = new URI(targetURIStr);
+
             CavernURLGenerator urlGen = new CavernURLGenerator();
+            VOSURI targetVOSURI = urlGen.getURIFromPath(path);
             Direction direction = this.getDirection();
-            nodeURI = urlGen.getNodeURI(meta, sig, direction);
+
+//            nodeURI = urlGen.getNodeURI(meta, sig, direction);
+            nodeURI = urlGen.getNodeURI(token, targetVOSURI, direction);
             log.debug("Init node uri: " + nodeURI);
         }
     }

--- a/cavern/src/main/java/org/opencadc/cavern/files/FileAction.java
+++ b/cavern/src/main/java/org/opencadc/cavern/files/FileAction.java
@@ -70,17 +70,13 @@ package org.opencadc.cavern.files;
 import ca.nrc.cadc.rest.InlineContentHandler;
 import ca.nrc.cadc.rest.RestAction;
 import ca.nrc.cadc.util.PropertiesReader;
-import ca.nrc.cadc.util.StringUtil;
 import ca.nrc.cadc.vos.Direction;
 import ca.nrc.cadc.vos.VOSURI;
 
-import ca.nrc.cadc.vos.server.LocalServiceURI;
 import java.io.IOException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.attribute.GroupPrincipal;
 import java.nio.file.attribute.UserPrincipalLookupService;
 import java.security.AccessControlException;
 
@@ -94,13 +90,13 @@ import org.opencadc.cavern.PosixIdentityManager;
 public abstract class FileAction extends RestAction {
     private static final Logger log = Logger.getLogger(FileAction.class);
 
-    private static final String PREAUTH_INIT_PARAM = "isPreAuthRequest";
+//    private static final String PREAUTH_INIT_PARAM = "isPreAuthRequest";
 
-    private String root;
-    private UserPrincipalLookupService upLookupSvc;
-    private PosixIdentityManager identityManager;
+    protected String root;
+    protected UserPrincipalLookupService upLookupSvc;
+    protected PosixIdentityManager identityManager;
 
-    private VOSURI nodeURI;
+    protected VOSURI nodeURI;
 
     protected FileAction() {
         PropertiesReader pr = new PropertiesReader("Cavern.properties");
@@ -138,44 +134,5 @@ public abstract class FileAction extends RestAction {
 
     protected abstract Direction getDirection();
 
-    private void initTarget() throws AccessControlException, IOException, URISyntaxException {
-        if (nodeURI == null) {
-            String path = syncInput.getPath();
-
-            // Long marker as cavern debug is rather verbose
-            log.debug("--------------------------------------------------------------------------------");
-
-            // init param set in web.xml
-            // TODO: have something that responds if it is null??
-            String isPreAuth = initParams.get(PREAUTH_INIT_PARAM);
-            log.debug("isPreAuth value: " + isPreAuth);
-
-            if (isPreAuth.toLowerCase().equals("true")) {
-                if (!StringUtil.hasLength(path)) {
-                    throw new IllegalArgumentException("Invalid preauthorized request");
-                }
-                String[] parts = path.split("/");
-                log.debug(" number of parts in path: " + parts.length);
-                if (parts.length < 2) {
-                    throw new IllegalArgumentException("Invalid preauthorized request");
-                }
-
-                String token = parts[0];
-                log.debug("token: " + token);
-
-                CavernURLGenerator urlGen = new CavernURLGenerator();
-                VOSURI targetVOSURI = urlGen.getURIFromPath(path);
-                Direction direction = this.getDirection();
-
-                // preauth token is validated in this step. Exceptions are thrown
-                // if it's not valid
-                nodeURI = urlGen.getNodeURI(token, targetVOSURI, direction);
-                log.debug("Init node uri: " + nodeURI);
-            } else {
-                // TODO: this will be where a potentially different funciton from getNodeURI
-                // will be called, including setting up an authorizer.
-                throw new UnsupportedOperationException("non-preauth access to cavern files not supported yet.");
-            }
-        }
-    }
+    protected abstract void initTarget() throws AccessControlException, IOException, URISyntaxException;
 }

--- a/cavern/src/main/java/org/opencadc/cavern/files/FilePutAction.java
+++ b/cavern/src/main/java/org/opencadc/cavern/files/FilePutAction.java
@@ -3,7 +3,7 @@
 *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 *
-*  (c) 2017.                            (c) 2017.
+*  (c) 2022.                            (c) 2022.
 *  Government of Canada                 Gouvernement du Canada
 *  National Research Council            Conseil national de recherches
 *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -67,85 +67,26 @@
 
 package org.opencadc.cavern.files;
 
-
-import ca.nrc.cadc.vos.Direction;
-import ca.nrc.cadc.vos.Node;
-import ca.nrc.cadc.vos.VOS;
-import ca.nrc.cadc.vos.VOSURI;
-import ca.nrc.cadc.vos.server.NodePersistence;
-import ca.nrc.cadc.vos.server.PathResolver;
-
-import java.io.FileNotFoundException;
-import java.io.OutputStream;
-import java.nio.file.AccessDeniedException;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.NoSuchFileException;
-import java.nio.file.Path;
+import java.io.IOException;
+import java.net.URISyntaxException;
 import java.security.AccessControlException;
-
 import org.apache.log4j.Logger;
-import org.opencadc.cavern.FileSystemNodePersistence;
 
 /**
  *
  */
-public abstract class GetAction extends FileAction {
-    private static final Logger log = Logger.getLogger(GetActionBase.class);
+public class FilePutAction extends GetAction {
+    private static final Logger log = Logger.getLogger(FilePutAction.class);
 
-    public GetActionBase() {
+    public FilePutAction() {
         super();
     }
 
     @Override
-    public Direction getDirection() {
-        return Direction.pullFromVoSpace;
+    protected void initTarget() throws AccessControlException, IOException, URISyntaxException {
+        String path = syncInput.getPath();
+        // TODO: what would need to go in here for authorization?
+        nodeURI = FileUtil.initTarget(path);
     }
 
-    @Override
-    public void doAction() throws Exception {
-        try {
-            VOSURI nodeURI = getNodeURI();
-            FileSystem fs = FileSystems.getDefault();
-            Path source = fs.getPath(getRoot(), nodeURI.getPath());
-            if (!Files.exists(source)) {
-                // not found
-                syncOutput.setCode(404);
-                return;
-            }
-            if (!Files.isReadable(source)) {
-                // permission denied
-                syncOutput.setCode(403);
-                return;
-            }
-
-            // set HTTP headers.  To get node, resolve links but no authorization (null authorizer)
-            // This is appropriate for preauth endpoint, but the /cavern/files files requiring
-            // authentication will probably need the authorizer...
-            NodePersistence nodePersistence = new FileSystemNodePersistence();
-            PathResolver pathResolver = new PathResolver(nodePersistence, true);
-            Node node = pathResolver.resolveWithReadPermissionCheck(nodeURI, null, true);
-            String contentEncoding = node.getPropertyValue(VOS.PROPERTY_URI_CONTENTENCODING);
-            String contentLength = node.getPropertyValue(VOS.PROPERTY_URI_CONTENTLENGTH);
-            String contentMD5 = node.getPropertyValue(VOS.PROPERTY_URI_CONTENTMD5);
-            syncOutput.setHeader("Content-Disposition", "inline; filename=" + nodeURI.getName());
-            syncOutput.setHeader("Content-Type", node.getPropertyValue(VOS.PROPERTY_URI_TYPE));
-            syncOutput.setHeader("Content-Encoding", contentEncoding);
-            syncOutput.setHeader("Content-Length", contentLength);
-            syncOutput.setHeader("Content-MD5", contentMD5);
-
-            OutputStream out = syncOutput.getOutputStream();
-            log.debug("Starting copy of file " + source);
-            Files.copy(source, out);
-            log.debug("Completed copy of file " + source);
-            out.flush();
-        } catch (FileNotFoundException | NoSuchFileException e) {
-            log.debug(e);
-            syncOutput.setCode(404);
-        } catch (AccessControlException | AccessDeniedException e) {
-            log.debug(e);
-            syncOutput.setCode(403);
-        }
-    }
 }

--- a/cavern/src/main/java/org/opencadc/cavern/files/GetAction.java
+++ b/cavern/src/main/java/org/opencadc/cavern/files/GetAction.java
@@ -121,7 +121,9 @@ public class GetAction extends FileAction {
                 return;
             }
             
-            // set HTTP headers.  To get node, resolve links but no authorization (null authorizer) 
+            // set HTTP headers.  To get node, resolve links but no authorization (null authorizer)
+            // This is appropriate for preauth endpoint, but the /cavern/files files requiring
+            // authentication will probably need the authorizer...
             NodePersistence nodePersistence = new FileSystemNodePersistence();
             PathResolver pathResolver = new PathResolver(nodePersistence, true);
             Node node = pathResolver.resolveWithReadPermissionCheck(nodeURI, null, true);

--- a/cavern/src/main/java/org/opencadc/cavern/files/PreauthGetAction.java
+++ b/cavern/src/main/java/org/opencadc/cavern/files/PreauthGetAction.java
@@ -3,7 +3,7 @@
 *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 *
-*  (c) 2017.                            (c) 2017.
+*  (c) 2022.                            (c) 2022.
 *  Government of Canada                 Gouvernement du Canada
 *  National Research Council            Conseil national de recherches
 *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -68,84 +68,26 @@
 package org.opencadc.cavern.files;
 
 
-import ca.nrc.cadc.vos.Direction;
-import ca.nrc.cadc.vos.Node;
-import ca.nrc.cadc.vos.VOS;
-import ca.nrc.cadc.vos.VOSURI;
-import ca.nrc.cadc.vos.server.NodePersistence;
-import ca.nrc.cadc.vos.server.PathResolver;
-
-import java.io.FileNotFoundException;
-import java.io.OutputStream;
-import java.nio.file.AccessDeniedException;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.NoSuchFileException;
-import java.nio.file.Path;
+import java.io.IOException;
+import java.net.URISyntaxException;
 import java.security.AccessControlException;
-
 import org.apache.log4j.Logger;
-import org.opencadc.cavern.FileSystemNodePersistence;
+
 
 /**
  *
  */
-public abstract class GetAction extends FileAction {
-    private static final Logger log = Logger.getLogger(GetActionBase.class);
+public class PreauthGetAction extends GetAction {
+    private static final Logger log = Logger.getLogger(PreauthGetAction.class);
 
-    public GetActionBase() {
+    public PreauthGetAction() {
         super();
     }
 
     @Override
-    public Direction getDirection() {
-        return Direction.pullFromVoSpace;
+    protected void initTarget() throws AccessControlException, IOException, URISyntaxException {
+        String path = syncInput.getPath();
+        nodeURI = FileUtil.initPreauthTarget(path, getDirection());
     }
 
-    @Override
-    public void doAction() throws Exception {
-        try {
-            VOSURI nodeURI = getNodeURI();
-            FileSystem fs = FileSystems.getDefault();
-            Path source = fs.getPath(getRoot(), nodeURI.getPath());
-            if (!Files.exists(source)) {
-                // not found
-                syncOutput.setCode(404);
-                return;
-            }
-            if (!Files.isReadable(source)) {
-                // permission denied
-                syncOutput.setCode(403);
-                return;
-            }
-
-            // set HTTP headers.  To get node, resolve links but no authorization (null authorizer)
-            // This is appropriate for preauth endpoint, but the /cavern/files files requiring
-            // authentication will probably need the authorizer...
-            NodePersistence nodePersistence = new FileSystemNodePersistence();
-            PathResolver pathResolver = new PathResolver(nodePersistence, true);
-            Node node = pathResolver.resolveWithReadPermissionCheck(nodeURI, null, true);
-            String contentEncoding = node.getPropertyValue(VOS.PROPERTY_URI_CONTENTENCODING);
-            String contentLength = node.getPropertyValue(VOS.PROPERTY_URI_CONTENTLENGTH);
-            String contentMD5 = node.getPropertyValue(VOS.PROPERTY_URI_CONTENTMD5);
-            syncOutput.setHeader("Content-Disposition", "inline; filename=" + nodeURI.getName());
-            syncOutput.setHeader("Content-Type", node.getPropertyValue(VOS.PROPERTY_URI_TYPE));
-            syncOutput.setHeader("Content-Encoding", contentEncoding);
-            syncOutput.setHeader("Content-Length", contentLength);
-            syncOutput.setHeader("Content-MD5", contentMD5);
-
-            OutputStream out = syncOutput.getOutputStream();
-            log.debug("Starting copy of file " + source);
-            Files.copy(source, out);
-            log.debug("Completed copy of file " + source);
-            out.flush();
-        } catch (FileNotFoundException | NoSuchFileException e) {
-            log.debug(e);
-            syncOutput.setCode(404);
-        } catch (AccessControlException | AccessDeniedException e) {
-            log.debug(e);
-            syncOutput.setCode(403);
-        }
-    }
 }

--- a/cavern/src/main/java/org/opencadc/cavern/files/PreauthPutAction.java
+++ b/cavern/src/main/java/org/opencadc/cavern/files/PreauthPutAction.java
@@ -3,7 +3,7 @@
 *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 *
-*  (c) 2017.                            (c) 2017.
+*  (c) 2022.                            (c) 2022.
 *  Government of Canada                 Gouvernement du Canada
 *  National Research Council            Conseil national de recherches
 *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -68,84 +68,26 @@
 package org.opencadc.cavern.files;
 
 
-import ca.nrc.cadc.vos.Direction;
-import ca.nrc.cadc.vos.Node;
-import ca.nrc.cadc.vos.VOS;
-import ca.nrc.cadc.vos.VOSURI;
-import ca.nrc.cadc.vos.server.NodePersistence;
-import ca.nrc.cadc.vos.server.PathResolver;
-
-import java.io.FileNotFoundException;
-import java.io.OutputStream;
-import java.nio.file.AccessDeniedException;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.NoSuchFileException;
-import java.nio.file.Path;
+import java.io.IOException;
+import java.net.URISyntaxException;
 import java.security.AccessControlException;
-
 import org.apache.log4j.Logger;
-import org.opencadc.cavern.FileSystemNodePersistence;
+
 
 /**
  *
  */
-public abstract class GetAction extends FileAction {
-    private static final Logger log = Logger.getLogger(GetActionBase.class);
+public class PreauthPutAction extends GetAction {
+    private static final Logger log = Logger.getLogger(PreauthPutAction.class);
 
-    public GetActionBase() {
+    public PreauthPutAction() {
         super();
     }
 
     @Override
-    public Direction getDirection() {
-        return Direction.pullFromVoSpace;
+    protected void initTarget() throws AccessControlException, IOException, URISyntaxException {
+        String path = syncInput.getPath();
+        nodeURI = FileUtil.initPreauthTarget(path, getDirection());
     }
 
-    @Override
-    public void doAction() throws Exception {
-        try {
-            VOSURI nodeURI = getNodeURI();
-            FileSystem fs = FileSystems.getDefault();
-            Path source = fs.getPath(getRoot(), nodeURI.getPath());
-            if (!Files.exists(source)) {
-                // not found
-                syncOutput.setCode(404);
-                return;
-            }
-            if (!Files.isReadable(source)) {
-                // permission denied
-                syncOutput.setCode(403);
-                return;
-            }
-
-            // set HTTP headers.  To get node, resolve links but no authorization (null authorizer)
-            // This is appropriate for preauth endpoint, but the /cavern/files files requiring
-            // authentication will probably need the authorizer...
-            NodePersistence nodePersistence = new FileSystemNodePersistence();
-            PathResolver pathResolver = new PathResolver(nodePersistence, true);
-            Node node = pathResolver.resolveWithReadPermissionCheck(nodeURI, null, true);
-            String contentEncoding = node.getPropertyValue(VOS.PROPERTY_URI_CONTENTENCODING);
-            String contentLength = node.getPropertyValue(VOS.PROPERTY_URI_CONTENTLENGTH);
-            String contentMD5 = node.getPropertyValue(VOS.PROPERTY_URI_CONTENTMD5);
-            syncOutput.setHeader("Content-Disposition", "inline; filename=" + nodeURI.getName());
-            syncOutput.setHeader("Content-Type", node.getPropertyValue(VOS.PROPERTY_URI_TYPE));
-            syncOutput.setHeader("Content-Encoding", contentEncoding);
-            syncOutput.setHeader("Content-Length", contentLength);
-            syncOutput.setHeader("Content-MD5", contentMD5);
-
-            OutputStream out = syncOutput.getOutputStream();
-            log.debug("Starting copy of file " + source);
-            Files.copy(source, out);
-            log.debug("Completed copy of file " + source);
-            out.flush();
-        } catch (FileNotFoundException | NoSuchFileException e) {
-            log.debug(e);
-            syncOutput.setCode(404);
-        } catch (AccessControlException | AccessDeniedException e) {
-            log.debug(e);
-            syncOutput.setCode(403);
-        }
-    }
 }

--- a/cavern/src/main/java/org/opencadc/cavern/files/PutAction.java
+++ b/cavern/src/main/java/org/opencadc/cavern/files/PutAction.java
@@ -97,7 +97,7 @@ import org.opencadc.cavern.nodes.NodeUtil;
  *
  * @author majorb
  */
-public class PutAction extends FileAction {
+public abstract class PutAction extends FileAction {
     private static final Logger log = Logger.getLogger(PutAction.class);
 
     private static final String INPUT_STREAM = "in";

--- a/cavern/src/main/webapp/WEB-INF/web.xml
+++ b/cavern/src/main/webapp/WEB-INF/web.xml
@@ -122,15 +122,15 @@
   </servlet>
 
   <servlet>
-    <servlet-name>AuthFilesServlet</servlet-name>
+    <servlet-name>PreauthFileServlet</servlet-name>
     <servlet-class>ca.nrc.cadc.rest.RestServlet</servlet-class>
     <init-param>
       <param-name>get</param-name>
-      <param-value>org.opencadc.cavern.files.GetAction</param-value>
+      <param-value>org.opencadc.cavern.files.PreauthGetAction</param-value>
     </init-param>
     <init-param>
       <param-name>put</param-name>
-      <param-value>org.opencadc.cavern.files.PutAction</param-value>
+      <param-value>org.opencadc.cavern.files.PreauthPutAction</param-value>
     </init-param>
     <init-param>
       <param-name>isPreAuthRequest</param-name>
@@ -155,15 +155,11 @@
         <servlet-class>ca.nrc.cadc.rest.RestServlet</servlet-class>
         <init-param>
             <param-name>get</param-name>
-            <param-value>org.opencadc.cavern.files.GetAction</param-value>
+            <param-value>org.opencadc.cavern.files.FileGetAction</param-value>
         </init-param>
         <init-param>
             <param-name>put</param-name>
-            <param-value>org.opencadc.cavern.files.PutAction</param-value>
-        </init-param>
-        <init-param>
-          <param-name>isPreAuthRequest</param-name>
-          <param-value>false</param-value>
+            <param-value>org.opencadc.cavern.files.FilePutAction</param-value>
         </init-param>
         <!--
         <init-param>
@@ -235,7 +231,7 @@
   </servlet-mapping>
 
   <servlet-mapping>
-    <servlet-name>AuthFilesServlet</servlet-name>
+    <servlet-name>PreauthFileServlet</servlet-name>
     <url-pattern>/preauth/*</url-pattern>
   </servlet-mapping>
 

--- a/cavern/src/main/webapp/WEB-INF/web.xml
+++ b/cavern/src/main/webapp/WEB-INF/web.xml
@@ -120,6 +120,35 @@
     </init-param>
     <load-on-startup>2</load-on-startup>
   </servlet>
+
+  <servlet>
+    <servlet-name>AuthFilesServlet</servlet-name>
+    <servlet-class>ca.nrc.cadc.rest.RestServlet</servlet-class>
+    <init-param>
+      <param-name>get</param-name>
+      <param-value>org.opencadc.cavern.files.GetAction</param-value>
+    </init-param>
+    <init-param>
+      <param-name>put</param-name>
+      <param-value>org.opencadc.cavern.files.PutAction</param-value>
+    </init-param>
+    <init-param>
+      <param-name>isPreAuthRequest</param-name>
+      <param-value>true</param-value>
+    </init-param>
+    <!--
+    <init-param>
+        <param-name>post</param-name>
+        <param-value>org.opencadc.cavern.files.PostAction</param-value>
+    </init-param>
+
+    <init-param>
+        <param-name>delete</param-name>
+        <param-value>org.opencadc.cavern.files.DeleteAction</param-value>
+    </init-param>
+    -->
+    <load-on-startup>2</load-on-startup>
+  </servlet>
   
   <servlet>
     <servlet-name>FilesServlet</servlet-name>
@@ -131,6 +160,10 @@
         <init-param>
             <param-name>put</param-name>
             <param-value>org.opencadc.cavern.files.PutAction</param-value>
+        </init-param>
+        <init-param>
+          <param-name>isPreAuthRequest</param-name>
+          <param-value>false</param-value>
         </init-param>
         <!--
         <init-param>
@@ -202,8 +235,13 @@
   </servlet-mapping>
 
   <servlet-mapping>
-    <servlet-name>FilesServlet</servlet-name>
+    <servlet-name>AuthFilesServlet</servlet-name>
     <url-pattern>/preauth/*</url-pattern>
+  </servlet-mapping>
+
+  <servlet-mapping>
+    <servlet-name>FilesServlet</servlet-name>
+    <url-pattern>/files/*</url-pattern>
   </servlet-mapping>
 
   

--- a/cavern/src/main/webapp/WEB-INF/web.xml
+++ b/cavern/src/main/webapp/WEB-INF/web.xml
@@ -203,8 +203,9 @@
 
   <servlet-mapping>
     <servlet-name>FilesServlet</servlet-name>
-    <url-pattern>/files/*</url-pattern>
+    <url-pattern>/preauth/*</url-pattern>
   </servlet-mapping>
+
   
   <!-- Transfer servlet endpoints -->
   <servlet-mapping>

--- a/cavern/src/main/webapp/capabilities.xml
+++ b/cavern/src/main/webapp/capabilities.xml
@@ -90,6 +90,17 @@
     </interface>
   </capability>
    -->
+
+  <capability standardID="ivo://ivoa.net/std/VOSpace/v2.x#files">
+    <interface xsi:type="vs:ParamHTTP" role="std">
+      <accessURL use="base">https://replace.com/cavern/files</accessURL>
+      <securityMethod/>
+      <securityMethod standardID="ivo://ivoa.net/sso#cookie"/>
+      <securityMethod standardID="ivo://ivoa.net/sso#tls-with-certificate"/>
+      <securityMethod standardID="ivo://ivoa.net/sso#token"/>
+    </interface>
+
+  </capability>
   
   <capability standardID="vos://cadc.nrc.ca~vospace/CADC/std/archive#file-1.0">
     <interface xsi:type="vs:ParamHTTP" role="std">

--- a/cavern/src/main/webapp/capabilities.xml
+++ b/cavern/src/main/webapp/capabilities.xml
@@ -41,7 +41,7 @@
   
   <capability standardID="ivo://ivoa.net/std/VOSpace/v2.x#files">
     <interface xsi:type="vs:ParamHTTP" role="std">
-      <accessURL use="base">https://replace.com/cavern/files</accessURL>
+      <accessURL use="base">https://replace.com/cavern/preauth</accessURL>
       <securityMethod/>
       <securityMethod standardID="ivo://ivoa.net/sso#cookie"/>
       <securityMethod standardID="ivo://ivoa.net/sso#tls-with-certificate"/>
@@ -93,7 +93,7 @@
   
   <capability standardID="vos://cadc.nrc.ca~vospace/CADC/std/archive#file-1.0">
     <interface xsi:type="vs:ParamHTTP" role="std">
-      <accessURL use="full">https://replace.com/cavern/files</accessURL>
+      <accessURL use="full">https://replace.com/cavern/preauth</accessURL>
       <securityMethod/>
       <securityMethod standardID="ivo://ivoa.net/sso#cookie"/>
       <securityMethod standardID="ivo://ivoa.net/sso#tls-with-certificate"/>

--- a/cavern/src/test/java/org/opencadc/cavern/files/CavernURLGeneratorTest.java
+++ b/cavern/src/test/java/org/opencadc/cavern/files/CavernURLGeneratorTest.java
@@ -249,15 +249,24 @@ public class CavernURLGeneratorTest
             String suri = p.getEndpoint();
             log.debug("Transfer URI: " + suri);
             Assert.assertNotNull(suri);
-            URI transferURI = new URI(suri);
+            VOSURI transferURI = new VOSURI(new URI(suri));
             Assert.assertTrue(transferURI.getPath().endsWith("/" + TEST_FILE));
 
             String path = transferURI.getPath();
             log.debug("Path: " + path);
             String[] parts = path.split("/");
-            String sig = parts[4];
-            String meta = parts[3];
-            VOSURI retURI = urlGen.getNodeURI(meta, sig, Direction.pullFromVoSpace);
+//            String sig = parts[4];
+//            String meta = parts[3];
+            String token = parts[3];
+
+            int firstSlashIndex = path.indexOf("/");
+            String pathStr = path.substring(firstSlashIndex + 1);
+            log.debug("path: " + pathStr);
+            String targetURIStr = baseURI.toString() + "/" + pathStr;
+            log.debug("target URI for validating token: " + targetURIStr);
+            VOSURI targetURI = new VOSURI(new URI(targetURIStr));
+
+            VOSURI retURI = urlGen.getNodeURI(token, targetURI, Direction.pullFromVoSpace);
             Assert.assertEquals(nodeURI, retURI);
 
         } catch (Exception unexpected) {
@@ -266,38 +275,160 @@ public class CavernURLGeneratorTest
         }
     }
 
-    // TODO: acl specific codes will be moved to a library, enable the test after
-    @Ignore
-    @Test
-    public void testWrongDirection() {
-        try {
+//    // TODO: acl specific codes will be moved to a library, enable the test after
+//    @Ignore
+//    @Test
+//    public void testWrongDirection() {
+//        try {
+//
+//            TestTransferGenerator urlGen = new TestTransferGenerator(ROOT);
+//            VOSURI nodeURI = new VOSURI(baseURI + "/" + TEST_DIR + "/" + TEST_FILE);
+//            List<Protocol> protos = new ArrayList<>();
+//            protos.add(new Protocol(VOS.PROTOCOL_HTTPS_GET));
+//            final Transfer trans = new Transfer(nodeURI.getURI(), Direction.pullFromVoSpace);
+//            trans.getProtocols().addAll(protos);
+//            View view = null;
+//            Job job = null;
+//            List<Protocol> result = urlGen.getEndpoints(nodeURI, trans, view, job, null);
+//            Protocol p = result.get(0);
+//            Assert.assertNotNull(p);
+//            String suri = p.getEndpoint();
+//            log.debug("Transfer URI: " + suri);
+//            Assert.assertNotNull(suri);
+//            URI transferURI = new URI(suri);
+//
+//            String path = transferURI.getPath();
+//            String[] parts = path.split("/");
+//            String sig = parts[4];
+//            String meta = parts[3];
+//            try {
+//                urlGen.getNodeURI(meta, sig, Direction.pushToVoSpace);
+//                Assert.fail();
+//            } catch (IllegalArgumentException e) {
+//                Assert.assertTrue(e.getMessage().contains("Wrong direction"));
+//            }
+//
+//        } catch (Exception unexpected) {
+//            log.error("unexpected exception", unexpected);
+//            Assert.fail("unexpected exception: " + unexpected);
+//        }
+//    }
 
-            TestTransferGenerator urlGen = new TestTransferGenerator(ROOT);
-            VOSURI nodeURI = new VOSURI(baseURI + "/" + TEST_DIR + "/" + TEST_FILE);
-            List<Protocol> protos = new ArrayList<>();
-            protos.add(new Protocol(VOS.PROTOCOL_HTTPS_GET));
-            final Transfer trans = new Transfer(nodeURI.getURI(), Direction.pullFromVoSpace);
-            trans.getProtocols().addAll(protos);
-            View view = null;
-            Job job = null;
-            List<Protocol> result = urlGen.getEndpoints(nodeURI, trans, view, job, null);
-            Protocol p = result.get(0);
-            Assert.assertNotNull(p);
-            String suri = p.getEndpoint();
-            log.debug("Transfer URI: " + suri);
-            Assert.assertNotNull(suri);
-            URI transferURI = new URI(suri);
-            
-            String path = transferURI.getPath();
-            String[] parts = path.split("/");
-            String sig = parts[4];
-            String meta = parts[3];
-            try {
-                urlGen.getNodeURI(meta, sig, Direction.pushToVoSpace);
-                Assert.fail();
-            } catch (IllegalArgumentException e) {
-                Assert.assertTrue(e.getMessage().contains("Wrong direction"));
-            }
+//    // TODO: acl specific codes will be moved to a library, enable the test after
+//    @Ignore
+//    @Test
+//    public void testInvalidSignature() {
+//        try {
+//            // Have to generate a token with a fouled signature?
+//            // Is this even necessary considering Token Tool is being used, and those tests should be there?
+//
+//            TestTransferGenerator urlGen = new TestTransferGenerator(ROOT);
+//            VOSURI nodeURI = new VOSURI(baseURI + "/" + TEST_DIR + "/" + TEST_FILE);
+//            List<Protocol> protos = new ArrayList<>();
+//            protos.add(new Protocol(VOS.PROTOCOL_HTTPS_GET));
+//            final Transfer trans = new Transfer(nodeURI.getURI(), Direction.pullFromVoSpace);
+//            trans.getProtocols().addAll(protos);
+//            View view = null;
+//            Job job = null;
+//            List<Protocol> result = urlGen.getEndpoints(nodeURI, trans, view, job, null);
+//            Protocol p = result.get(0);
+//            Assert.assertNotNull(p);
+//            String suri = p.getEndpoint();
+//            log.debug("Transfer URI: " + suri);
+//            Assert.assertNotNull(suri);
+//            URI transferURI = new URI(suri);
+//
+//            String path = transferURI.getPath();
+//            String[] parts = path.split("/");
+//            //String sig = parts[4];
+//            String meta = parts[3];
+//            try {
+//                urlGen.getNodeURI(meta, "12345", Direction.pushToVoSpace);
+//                Assert.fail();
+//            } catch (AccessControlException e) {
+//                // expected
+//            }
+//
+//        } catch (Exception unexpected) {
+//            log.error("unexpected exception", unexpected);
+//            Assert.fail("unexpected exception: " + unexpected);
+//        }
+//    }
+
+//    // TODO: acl specific codes will be moved to a library, enable the test after
+//    @Ignore
+//    @Test
+//    public void testMetaTampered() {
+//        // TODO: test stil relevant?
+//        try {
+//
+//            TestTransferGenerator urlGen = new TestTransferGenerator(ROOT);
+//            VOSURI nodeURI = new VOSURI(baseURI + "/" + TEST_DIR + "/" + TEST_FILE);
+//            List<Protocol> protos = new ArrayList<>();
+//            protos.add(new Protocol(VOS.PROTOCOL_HTTPS_GET));
+//            final Transfer trans = new Transfer(nodeURI.getURI(), Direction.pullFromVoSpace);
+//            trans.getProtocols().addAll(protos);
+//            View view = null;
+//            Job job = null;
+//            List<Protocol> result = urlGen.getEndpoints(nodeURI, trans, view, job, null);
+//            Protocol p = result.get(0);
+//            Assert.assertNotNull(p);
+//            String suri = p.getEndpoint();
+//            log.debug("Transfer URI: " + suri);
+//            Assert.assertNotNull(suri);
+//            URI transferURI = new URI(suri);
+//
+//            Assert.assertTrue(transferURI.getPath().endsWith("/" + TEST_FILE));
+//
+//            String path = transferURI.getPath();
+//            log.debug("Path: " + path);
+//            // Have to generate a token with different meta and pass it in, using token Tool?
+////            String[] parts = path.split("/");
+////            URI targetURI = urlGen.getURIFromPath(path);
+//////            String sig = parts[4];
+////            //String meta = parts[3];
+////            String token = parts[3];
+////            VOSURI altURI = new VOSURI(baseURI + "/" + TEST_DIR + "/fakeFile");
+//////            String meta = new String(Base64.encode(("node=" + altURI.toString() + "&dir=pullFromVoSpace").getBytes()));
+////            try {
+//////                VOSURI retURI = urlGen.getNodeURI(meta, sig, Direction.pullFromVoSpace);
+////                VOSURI retURI = urlGen.getNodeURI(token, targetURI, Direction.pullFromVoSpace);
+////                Assert.fail();
+////            } catch (AccessControlException e) {
+////                // expected
+////            }
+//
+//        } catch (Exception unexpected) {
+//            log.error("unexpected exception", unexpected);
+//            Assert.fail("unexpected exception: " + unexpected);
+//        }
+//    }
+
+//    @Test
+//    public void testBase64URI() {
+//        // not relelvant as base64URLDecode not in CavernURLGenerator anymore
+//        String[] testStrings = {
+//            "abcde",
+//            "ab//de",
+//            "ab/de",
+//            "ab++///+de"
+//        };
+//        for (String s : testStrings) {
+//            log.debug("testing: " + s);
+//            Assert.assertEquals(CavernURLGenerator.base64URLDecode(CavernURLGenerator.base64URLEncode(s)), s);
+//        }
+//    }
+
+
+    @Test
+    public void testGetURLFromPathWithToken() {
+        try {
+            String path = "token/path/to/file";
+            String expectedPath = "vos://example.org~vospace/path/to/file";
+            VOSURI expectedURI = new VOSURI(new URI(expectedPath));
+
+            VOSURI generatedURI = CavernURLGenerator.getURIFromPath(path);
+            Assert.assertEquals("expected and generated URI don't match: ", expectedURI, generatedURI);
 
         } catch (Exception unexpected) {
             log.error("unexpected exception", unexpected);
@@ -305,102 +436,6 @@ public class CavernURLGeneratorTest
         }
     }
 
-    // TODO: acl specific codes will be moved to a library, enable the test after
-    @Ignore
-    @Test
-    public void testInvalidSignature() {
-        try {
-
-            TestTransferGenerator urlGen = new TestTransferGenerator(ROOT);
-            VOSURI nodeURI = new VOSURI(baseURI + "/" + TEST_DIR + "/" + TEST_FILE);
-            List<Protocol> protos = new ArrayList<>();
-            protos.add(new Protocol(VOS.PROTOCOL_HTTPS_GET));
-            final Transfer trans = new Transfer(nodeURI.getURI(), Direction.pullFromVoSpace);
-            trans.getProtocols().addAll(protos);
-            View view = null;
-            Job job = null;
-            List<Protocol> result = urlGen.getEndpoints(nodeURI, trans, view, job, null);
-            Protocol p = result.get(0);
-            Assert.assertNotNull(p);
-            String suri = p.getEndpoint();
-            log.debug("Transfer URI: " + suri);
-            Assert.assertNotNull(suri);
-            URI transferURI = new URI(suri);
-            
-            String path = transferURI.getPath();
-            String[] parts = path.split("/");
-            //String sig = parts[4];
-            String meta = parts[3];
-            try {
-                urlGen.getNodeURI(meta, "12345", Direction.pushToVoSpace);
-                Assert.fail();
-            } catch (AccessControlException e) {
-                // expected
-            }
-
-        } catch (Exception unexpected) {
-            log.error("unexpected exception", unexpected);
-            Assert.fail("unexpected exception: " + unexpected);
-        }
-    }
-
-    // TODO: acl specific codes will be moved to a library, enable the test after
-    @Ignore
-    @Test
-    public void testMetaTampered() {
-        try {
-
-            TestTransferGenerator urlGen = new TestTransferGenerator(ROOT);
-            VOSURI nodeURI = new VOSURI(baseURI + "/" + TEST_DIR + "/" + TEST_FILE);
-            List<Protocol> protos = new ArrayList<>();
-            protos.add(new Protocol(VOS.PROTOCOL_HTTPS_GET));
-            final Transfer trans = new Transfer(nodeURI.getURI(), Direction.pullFromVoSpace);
-            trans.getProtocols().addAll(protos);
-            View view = null;
-            Job job = null;
-            List<Protocol> result = urlGen.getEndpoints(nodeURI, trans, view, job, null);
-            Protocol p = result.get(0);
-            Assert.assertNotNull(p);
-            String suri = p.getEndpoint();
-            log.debug("Transfer URI: " + suri);
-            Assert.assertNotNull(suri);
-            URI transferURI = new URI(suri);
-            
-            Assert.assertTrue(transferURI.getPath().endsWith("/" + TEST_FILE));
-
-            String path = transferURI.getPath();
-            log.debug("Path: " + path);
-            String[] parts = path.split("/");
-            String sig = parts[4];
-            //String meta = parts[3];
-            VOSURI altURI = new VOSURI(baseURI + "/" + TEST_DIR + "/fakeFile");
-            String meta = new String(Base64.encode(("node=" + altURI.toString() + "&dir=pullFromVoSpace").getBytes()));
-            try {
-                VOSURI retURI = urlGen.getNodeURI(meta, sig, Direction.pullFromVoSpace);
-                Assert.fail();
-            } catch (AccessControlException e) {
-                // expected
-            }
-
-        } catch (Exception unexpected) {
-            log.error("unexpected exception", unexpected);
-            Assert.fail("unexpected exception: " + unexpected);
-        }
-    }
-
-    @Test
-    public void testBase64URI() {
-        String[] testStrings = {
-            "abcde",
-            "ab//de",
-            "ab/de",
-            "ab++///+de"
-        };
-        for (String s : testStrings) {
-            log.debug("testing: " + s);
-            Assert.assertEquals(CavernURLGenerator.base64URLDecode(CavernURLGenerator.base64URLEncode(s)), s);
-        }
-    }
 
     class TestTransferGenerator extends CavernURLGenerator {
 


### PR DESCRIPTION
cavern/files is not supported beyond the URL (no authentication or actual files returned, just an unsupported message.) cavern/preauth endpoint maintains existing preauth behaviour. Integration tests run fully. 