### PR TITLE
CADC-11904: support '!' and '~' in URI authority in preauth tokens

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.11
+    - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:
-        java-version: 1.11
+        java-version: 1.8
 
     - name: build and test cadc-vos
       run: cd cadc-vos && ../gradlew --info clean build javadoc install

--- a/cadc-vos/build.gradle
+++ b/cadc-vos/build.gradle
@@ -14,7 +14,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '1.2.2'
+version = '1.2.3'
 
 description = 'OpenCADC VOSpace client library'
 def git_url = 'https://github.com/opencadc/vos'

--- a/cadc-vos/src/main/java/ca/nrc/cadc/vos/VOSURI.java
+++ b/cadc-vos/src/main/java/ca/nrc/cadc/vos/VOSURI.java
@@ -3,7 +3,7 @@
 *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 *
-*  (c) 2009.                            (c) 2009.
+*  (c) 2022.                            (c) 2022.
 *  Government of Canada                 Gouvernement du Canada
 *  National Research Council            Conseil national de recherches
 *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -308,5 +308,31 @@ public class VOSURI
         {
             throw new RuntimeException("BUG: failed to create service URI from VOSURI: " + vosURI);
         }
+    }
+
+    /**
+     * Return the service uri in the form common to CADC code.
+     * e.g.
+     * for VOSURI("vos://cadc.nrc.ca!vospace/temp/tempFile.txt"),
+     * it returns:
+     * VOSURI("vos://cadc.nrc.ca~vospace/temp/tempFile.txt")
+     *
+     * @author Helena Jeeves, Oct 12/2022
+     */
+    public VOSURI getCommonFormURI()
+    {
+        String authority = getAuthority();
+        authority = authority.replace('!', '~');
+
+        try
+        {
+            // Only the authority string should be changing.
+            return new VOSURI(new URI(getScheme(), authority, getPath(), getQuery(), getFragment()));
+        }
+        catch (URISyntaxException e)
+        {
+            throw new IllegalArgumentException("URI malformed: " + vosURI.toString());
+        }
+
     }
 }

--- a/cadc-vos/src/test/java/ca/nrc/cadc/vos/VOSURITest.java
+++ b/cadc-vos/src/test/java/ca/nrc/cadc/vos/VOSURITest.java
@@ -3,7 +3,7 @@
  *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
  **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
  *
- *  (c) 2009.                            (c) 2009.
+ *  (c) 2022.                            (c) 2022.
  *  Government of Canada                 Gouvernement du Canada
  *  National Research Council            Conseil national de recherches
  *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -431,4 +431,38 @@ public class VOSURITest
             Assert.fail("unexpected exception: " + unexpected);
         }
     }
+
+    @Test
+    public void testCommonForm()
+    {
+        try
+        {
+            VOSURI expectedURI = new VOSURI(new URI("vos://cadc.nrc.ca~vospace/test/file.txt"));
+            String fileURI = "vos://cadc.nrc.ca!vospace/test/file.txt";
+            VOSURI vos = new VOSURI(new URI(fileURI));
+            log.debug("input URI: " + vos.toString());
+            VOSURI commonFormURI = vos.getCommonFormURI();
+            log.debug("common form URI: " + commonFormURI.toString());
+            Assert.assertEquals(expectedURI, commonFormURI);
+            Assert.assertTrue("common form authority doesn't have ~: "
+                + commonFormURI, commonFormURI.getAuthority().contains("~"));
+
+            // This one should stay the same
+            fileURI = "vos://cadc.nrc.ca~vospace/test/file.txt";
+            vos = new VOSURI(new URI(fileURI));
+            log.debug("input URI: " + vos.toString());
+            commonFormURI = vos.getCommonFormURI();
+            log.debug("common form URI: " + commonFormURI.toString());
+            Assert.assertEquals(expectedURI, commonFormURI);
+            Assert.assertTrue("common form authority doesn't have ~: "
+                + commonFormURI, commonFormURI.getAuthority().contains("~"));
+
+        }
+        catch(Exception unexpected)
+        {
+            log.error("unexpected exception", unexpected);
+            Assert.fail("unexpected exception: " + unexpected);
+        }
+    }
+
 }

--- a/cavern/VERSION
+++ b/cavern/VERSION
@@ -1,4 +1,4 @@
 ## deployable containers have a semantic and build tag
 # semantic version tag: major.minor
 # build version tag: timestamp
-TAGS="0.4.3 $(date -u +"%Y%m%dT%H%M%S")"
+TAGS="0.4.4 $(date -u +"%Y%m%dT%H%M%S")"

--- a/cavern/build.gradle
+++ b/cavern/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     compile 'org.opencadc:cadc-uws-server:[1.2.5,)'
     compile 'org.opencadc:cadc-cdp:[1.0,)'
     compile 'org.opencadc:cadc-gms:[1.0.0,)'
-    compile 'org.opencadc:cadc-vos:[1.2.0,)'
+    compile 'org.opencadc:cadc-vos:[1.2.3,)'
     compile 'org.opencadc:cadc-vos-server:[1.3,)'
     compile 'org.opencadc:cadc-dali:[1.0,)'
     compile 'org.opencadc:caom2:[2.3.3,)'

--- a/cavern/src/main/java/org/opencadc/cavern/files/FileAction.java
+++ b/cavern/src/main/java/org/opencadc/cavern/files/FileAction.java
@@ -94,7 +94,6 @@ import java.nio.file.Paths;
 import java.nio.file.attribute.UserPrincipalLookupService;
 import java.security.AccessControlException;
 
-import jdk.internal.loader.Resource;
 import org.apache.log4j.Logger;
 import org.opencadc.cavern.FileSystemNodePersistence;
 

--- a/cavern/src/main/webapp/WEB-INF/web.xml
+++ b/cavern/src/main/webapp/WEB-INF/web.xml
@@ -190,6 +190,10 @@
         <param-name>input</param-name>
         <param-value>/capabilities.xml</param-value>
     </init-param>
+    <init-param>
+      <param-name>head</param-name>
+      <param-value>ca.nrc.cadc.vosi.CapHeadAction</param-value>
+    </init-param>
     <load-on-startup>3</load-on-startup>
   </servlet>
 


### PR DESCRIPTION
Test added into TransferRunnerTest to check that URIs with both '~' and '!' in the authority are supported. Needed because the python code uses '!' (and other clients may as well.)  

Note change to VOSURI.java will require cadc-vos to be released as well as cavern code that needs reviewed before release.