### PR TITLE
CADC-12253: switch cavern to use uws postgres job persistence

### DIFF
--- a/cavern/Dockerfile
+++ b/cavern/Dockerfile
@@ -1,4 +1,4 @@
-FROM cadc-tomcat:latest
+FROM images.opencadc.org/library/cadc-tomcat:1
 
 ## cavern specific
 

--- a/cavern/README.md
+++ b/cavern/README.md
@@ -22,8 +22,23 @@ docker run -d --volume=/path/to/external/config:/config:ro --name cavern-tomcat 
 See the <a href="https://github.com/opencadc/docker-base/tree/master/cadc-tomcat">cadc-tomcat</a> image docs 
 for expected deployment and general config requirements.
 
-The following files are expected to be in /path/to/external/config:
-* Cavern.properties - see the version in this directory as an example
+Runtime configuration must be made available via the `/config` directory, including
+the following files:
+* Cavern.properties
 * LocalAuthority.properties
 
 For the SSS connection to LDAP to operate, the directory /var/lib/sss/pipes must be mapped to the same /var/lib/sss/pipes directory seen by the SSS daemon, either through a volume mount or some other means.  See the access control git hub project mentioned above for more information.
+
+
+### catalina.properties
+
+```
+# database connection pools
+org.opencadc.cavern.uws.maxActive={max connections for jobs pool}
+org.opencadc.cavern.uws.username={database username for jobs pool}
+org.opencadc.cavern.uws.password={database password for jobs pool}
+org.opencadc.cavern.uws.url=jdbc:postgresql://{server}/{database}
+```
+
+The `uws` pool manages (create, alter, drop) uws tables and manages the uws content (creates and modifies jobs in the uws
+schema when jobs are created and executed by users.

--- a/cavern/VERSION
+++ b/cavern/VERSION
@@ -1,4 +1,4 @@
 ## deployable containers have a semantic and build tag
 # semantic version tag: major.minor
 # build version tag: timestamp
-TAGS="0.4.5 $(date -u +"%Y%m%dT%H%M%S")"
+TAGS="0.4.6 $(date -u +"%Y%m%dT%H%M%S")"

--- a/cavern/build.gradle
+++ b/cavern/build.gradle
@@ -61,8 +61,8 @@ dependencies {
     compile 'org.opencadc:cadc-registry:[1.5.9,)'
     compile 'org.opencadc:cadc-vosi:[1.4.3,)'
     compile 'org.opencadc:cadc-rest:[1.3.14,)'
-    compile 'org.opencadc:cadc-uws:[1.0,)'
-    compile 'org.opencadc:cadc-uws-server:[1.2.5,)'
+    compile 'org.opencadc:cadc-uws:[1.0.3,)'
+    compile 'org.opencadc:cadc-uws-server:[1.2.9,)'
     compile 'org.opencadc:cadc-cdp:[1.0,)'
     compile 'org.opencadc:cadc-gms:[1.0.0,)'
     compile 'org.opencadc:cadc-vos:[1.2.3,)'
@@ -74,7 +74,7 @@ dependencies {
 
     runtime 'org.restlet.jee:org.restlet.ext.spring:2.0.2'
     runtime 'org.opencadc:cadc-access-control:[1.1.23,)'
-    runtime 'org.opencadc:cadc-access-control-identity:[1.1.0,)'
+    runtime 'org.opencadc:cadc-access-control-identity:[1.2.0,)'
 
     testCompile 'junit:junit:[4.0,)'
     testCompile 'xerces:xercesImpl:[2.0,)'

--- a/cavern/src/intTest/java/org/opencadc/cavern/AuthPutActionTest.java
+++ b/cavern/src/intTest/java/org/opencadc/cavern/AuthPutActionTest.java
@@ -105,7 +105,6 @@ import org.junit.Test;
 public class AuthPutActionTest {
 
     protected static Logger log = Logger.getLogger(AuthPutActionTest.class);
-
     protected static Subject cadcauthSubject;
     protected static Subject cadcregSubject;
     protected static String baseURIStr;
@@ -365,21 +364,24 @@ public class AuthPutActionTest {
 
 
     private static void verifyPut(VOSURI fileURI, String sourceFilename, String md5Sum) throws Throwable {
-        final Path filePath = Paths.get(sourceFilename);
+        // Pulls file from the build/resources/intTest directory
+        final File expectedFile = new File(sourceFilename);
         try {
             Subject.doAs(cadcauthSubject, new PrivilegedExceptionAction() {
                 @Override
                 public Object run() throws Exception {
                     Node n = vos.getNode(fileURI.getPath());
                     log.debug("MD5: " + n.getPropertyValue(VOS.PROPERTY_URI_CONTENTMD5) + " (expecting " + md5Sum + ")");
-                    Assert.assertEquals(("filename not as expected: "), filePath.getFileName().toString(), n.getName());
+                    Assert.assertEquals(("filename not as expected: "), expectedFile.getName(), n.getName());
                     long contentLength = Long.parseLong(n.getPropertyValue(VOS.PROPERTY_URI_CONTENTLENGTH));
-                    Assert.assertEquals(Files.size(filePath), contentLength);
+                    long expectedFileLength = expectedFile.length();
+                    Assert.assertEquals(expectedFileLength, contentLength);
                     Assert.assertEquals(md5Sum, n.getPropertyValue(VOS.PROPERTY_URI_CONTENTMD5));
                     return null;
                 }
             });
         } catch (PrivilegedActionException ioe) {
+            log.debug("verifyPut exception:" + ioe);
             Assert.fail("unable to set up test node");
         }
     }

--- a/cavern/src/intTest/java/org/opencadc/cavern/MountedContainerTest.java
+++ b/cavern/src/intTest/java/org/opencadc/cavern/MountedContainerTest.java
@@ -96,6 +96,7 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 
 import javax.security.auth.Subject;
 import org.apache.log4j.Level;
@@ -119,6 +120,7 @@ public class MountedContainerTest {
         Log4jInit.setLevel("org.opencadc.cavern", Level.INFO);
         Log4jInit.setLevel("ca.nrc.cadc.vospace", Level.INFO);
         Log4jInit.setLevel("ca.nrc.cadc.vos", Level.INFO);
+        Log4jInit.setLevel("ca.nrc.cadc.util", Level.INFO);
     }
     
     public MountedContainerTest() { 
@@ -127,6 +129,9 @@ public class MountedContainerTest {
     @BeforeClass
     public static void staticInit() throws Exception {
         SSL_CERT = FileUtil.getFileFromResource("x509_CADCRegtest1.pem", TransferRunnerTest.class);
+
+        Properties properties = System.getProperties();
+        properties.forEach((k,v) -> log.info(k + ":" + v));
 
         String uriProp = MountedContainerTest.class.getName() + ".baseURI";
         String uri = System.getProperty(uriProp);

--- a/cavern/src/main/java/org/opencadc/cavern/CavernInitAction.java
+++ b/cavern/src/main/java/org/opencadc/cavern/CavernInitAction.java
@@ -3,7 +3,7 @@
 *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 *
-*  (c) 2017.                            (c) 2017.
+*  (c) 2023.                            (c) 2023.
 *  Government of Canada                 Gouvernement du Canada
 *  National Research Council            Conseil national de recherches
 *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -67,24 +67,32 @@
 
 package org.opencadc.cavern;
 
-import ca.nrc.cadc.auth.AuthenticationUtil;
-import ca.nrc.cadc.uws.server.JobPersistence;
-import ca.nrc.cadc.uws.server.SimpleJobManager;
-
-import ca.nrc.cadc.uws.server.impl.PostgresJobPersistence;
+import ca.nrc.cadc.db.DBUtil;
+import ca.nrc.cadc.rest.InitAction;
+import ca.nrc.cadc.uws.server.impl.InitDatabaseUWS;
+import javax.sql.DataSource;
 import org.apache.log4j.Logger;
 
-//public abstract class JobManager extends SimpleJobManager
-public abstract class JobManager extends SimpleJobManager
-{
+/**
+ * Based on similar files from storage-inventory (luskan, by example)
+ * @author jeevesh
+ */
+public class CavernInitAction extends InitAction {
+    private static final Logger log = Logger.getLogger(CavernInitAction.class);
 
-    private static final Logger log = Logger.getLogger(JobManager.class);
-
-    protected static JobPersistence jp;
-
-    static {
-        log.info("Creating shared (postgres) job manager");
-        jp = new PostgresJobPersistence(AuthenticationUtil.getIdentityManager());
+    public CavernInitAction() {
     }
 
+    @Override
+    public void doInit() {
+        try {
+            // Init UWS database
+            DataSource uws = DBUtil.findJNDIDataSource("jdbc/uws");
+            InitDatabaseUWS uwsi = new InitDatabaseUWS(uws, null, "uws");
+            uwsi.doInit();
+
+        } catch (Exception ex) {
+            throw new RuntimeException("INIT FAIL", ex);
+        }
+    }
 }

--- a/cavern/src/main/java/org/opencadc/cavern/JobManager.java
+++ b/cavern/src/main/java/org/opencadc/cavern/JobManager.java
@@ -74,7 +74,6 @@ import ca.nrc.cadc.uws.server.SimpleJobManager;
 import ca.nrc.cadc.uws.server.impl.PostgresJobPersistence;
 import org.apache.log4j.Logger;
 
-//public abstract class JobManager extends SimpleJobManager
 public abstract class JobManager extends SimpleJobManager
 {
 

--- a/cavern/src/main/webapp/META-INF/context.xml
+++ b/cavern/src/main/webapp/META-INF/context.xml
@@ -2,5 +2,16 @@
 <Context>
 
     <WatchedResource>WEB-INF/web.xml</WatchedResource>
+    <Resource name="jdbc/uws"
+              auth="Container"
+              type="javax.sql.DataSource"
+              factory="org.apache.tomcat.jdbc.pool.DataSourceFactory" closeMethod="close"
+              minEvictableIdleTimeMillis="60000" timeBetweenEvictionRunsMillis="30000"
+              maxWait="20000"
+              initialSize="0" minIdle="0" maxIdle="${org.opencadc.cavern.uws.maxActive}" maxActive="${org.opencadc.cavern.uws.maxActive}"
+              username="${org.opencadc.cavern.uws.username}" password="${org.opencadc.cavern.uws.password}"
+              driverClassName="org.postgresql.Driver" url="${org.opencadc.cavern.uws.url}"
+              removeAbandoned="false"
+              testOnBorrow="true" validationQuery="select 123" />
     
 </Context>

--- a/cavern/src/main/webapp/WEB-INF/web.xml
+++ b/cavern/src/main/webapp/WEB-INF/web.xml
@@ -45,6 +45,10 @@
     <servlet-name>TransferServlet</servlet-name>
     <servlet-class>ca.nrc.cadc.uws.server.JobServlet</servlet-class>
     <init-param>
+        <param-name>init</param-name>
+        <param-value>org.opencadc.cavern.CavernInitAction</param-value>
+    </init-param>
+    <init-param>
         <param-name>get</param-name>
         <param-value>ca.nrc.cadc.uws.web.GetAction</param-value>
     </init-param>


### PR DESCRIPTION
rather than in-memory.  README updated to include catalina.properties changes. 

Small changes made in order for base int tests to run:
- location of cadc-tomcat pull updated
- use of Paths changed for use of Files class in AuthPutActionTest because this makes the int tests use resources from the correct build directory (instead of from the src directory) - test had been failing out of the box.
