### PR TITLE
add-packages Added sssd and acl packages that are missing from cavern.

### DIFF
--- a/cavern/Dockerfile
+++ b/cavern/Dockerfile
@@ -1,6 +1,7 @@
 FROM images.opencadc.org/library/cadc-tomcat:1
 
 ## cavern specific
+RUN dnf install -y sssd-client acl && dnf clean all
 
 # cavern needs:
 # - sssd-client 

--- a/cavern/VERSION
+++ b/cavern/VERSION
@@ -1,4 +1,4 @@
 ## deployable containers have a semantic and build tag
 # semantic version tag: major.minor
 # build version tag: timestamp
-TAGS="0.4.6 $(date -u +"%Y%m%dT%H%M%S")"
+TAGS="0.4.7 $(date -u +"%Y%m%dT%H%M%S")"


### PR DESCRIPTION
Note that currently there is already a [PR](https://github.com/opencadc/science-platform/pull/453) which deploys arc with version 0.4.7. We will need to update the PR to increment cavern deployment to 0.4.8 after this PR has been released.