### PR TITLE
enable cavern to handle links to external files

### DIFF
--- a/cadc-test-vos/build.gradle
+++ b/cadc-test-vos/build.gradle
@@ -16,7 +16,7 @@ sourceCompatibility = 11
 
 group = 'org.opencadc'
 
-version = '2.1.10'
+version = '2.1.11'
 
 description = 'OpenCADC VOSpace test library'
 def git_url = 'https://github.com/opencadc/vos'

--- a/cadc-test-vos/src/main/java/org/opencadc/conformance/vos/NodesTest.java
+++ b/cadc-test-vos/src/main/java/org/opencadc/conformance/vos/NodesTest.java
@@ -398,7 +398,7 @@ public class NodesTest extends VOSTest {
 
         try {
             // create a simple link node
-            String name = "testLinkNode";
+            String name = "testLinkNodeExternalFile";
             URL nodeURL = getNodeURL(nodesServiceURL, name);
             VOSURI nodeURI = getVOSURI(name);
             URI targetURI = URI.create("file:///path/to/external/data");

--- a/cadc-vos-server/build.gradle
+++ b/cadc-vos-server/build.gradle
@@ -16,7 +16,7 @@ sourceCompatibility = 11
 
 group = 'org.opencadc'
 
-version = '2.0.16'
+version = '2.0.17'
 
 description = 'OpenCADC VOSpace server'
 def git_url = 'https://github.com/opencadc/vos'

--- a/cadc-vos-server/src/main/java/org/opencadc/vospace/server/PathResolver.java
+++ b/cadc-vos-server/src/main/java/org/opencadc/vospace/server/PathResolver.java
@@ -71,6 +71,7 @@ package org.opencadc.vospace.server;
 
 import ca.nrc.cadc.auth.AuthenticationUtil;
 import ca.nrc.cadc.util.StringUtil;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -244,11 +245,15 @@ public class PathResolver {
      */
     public VOSURI validateTargetURI(LinkNode linkNode) throws Exception {
         LocalServiceURI localServiceURI = new LocalServiceURI(nodePersistence.getResourceID());
-        VOSURI targetURI = new VOSURI(linkNode.getTarget());
+        URI turi = linkNode.getTarget();
+        if (!"vos".equals(turi.getScheme())) {
+            throw NodeFault.InvalidArgument.getStatus("cannot navigate external link " + turi);
+        }
+        VOSURI targetURI = new VOSURI(turi);
 
         log.debug("Validating target: " + targetURI.getServiceURI() + " vs " + localServiceURI.getVOSBase().getServiceURI());
         if (!localServiceURI.getVOSBase().getServiceURI().equals(targetURI.getServiceURI())) {
-            throw NodeFault.InvalidArgument.getStatus("External link " + targetURI.getServiceURI().toASCIIString());
+            throw NodeFault.InvalidArgument.getStatus("cannot navigate external vospace link " + turi);
         }
         return targetURI;
     }

--- a/cavern/VERSION
+++ b/cavern/VERSION
@@ -1,6 +1,6 @@
 ## deployable containers have a semantic and build tag
 # semantic version tag: major.minor
 # build version tag: timestamp
-VER=0.7.10
+VER=0.7.11
 TAGS="${VER} ${VER}-$(date -u +"%Y%m%dT%H%M%S")"
 unset VER

--- a/cavern/build.gradle
+++ b/cavern/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation 'org.opencadc:cadc-dali:[1.0,)'
     implementation 'org.opencadc:cadc-pkg-server:[1.2.3,)'
     implementation 'org.opencadc:cadc-vos:[2.0.7,)'
-    implementation 'org.opencadc:cadc-vos-server:[2.0.15,)'
+    implementation 'org.opencadc:cadc-vos-server:[2.0.17,)'
 
     runtimeOnly 'org.opencadc:cadc-access-control-identity:[1.2.0,)'
 

--- a/cavern/src/intTest/java/org/opencadc/cavern/FilesTest.java
+++ b/cavern/src/intTest/java/org/opencadc/cavern/FilesTest.java
@@ -89,6 +89,8 @@ public class FilesTest extends org.opencadc.conformance.vos.FilesTest {
 
         // enables testDataNodePermission
         super.enableTestDataNodePermission(Constants.AUTH_TEST_CERT);
+
+        super.linkExternalFile = true;
     }
 
 }

--- a/cavern/src/intTest/java/org/opencadc/cavern/NodesTest.java
+++ b/cavern/src/intTest/java/org/opencadc/cavern/NodesTest.java
@@ -95,6 +95,7 @@ public class NodesTest extends org.opencadc.conformance.vos.NodesTest {
     public NodesTest() {
         super(Constants.RESOURCE_ID, Constants.TEST_CERT);
         super.linkNodeProps = false;       // xattrs on links not supported in posix filesystem
+        super.linkExternalFile = true;     // allow links to external filesystem using file:///path/target
         super.paginationSupported = false; // not implemented because it is not scalable
         super.nodelockSupported = false;   // not implemented, maybe never
         

--- a/cavern/src/main/java/org/opencadc/cavern/nodes/FileSystemNodePersistence.java
+++ b/cavern/src/main/java/org/opencadc/cavern/nodes/FileSystemNodePersistence.java
@@ -441,14 +441,16 @@ public class FileSystemNodePersistence implements NodePersistence {
 
         if (node instanceof LinkNode) {
             LinkNode ln = (LinkNode) node;
-            try {
-                PathResolver ps = new PathResolver(this, new VOSpaceAuthorizer(this));
-                ps.validateTargetURI(ln);
-            } catch (Exception ex) {
-                throw new UnsupportedOperationException("link to external resource", ex);
+            if (!"file".equals(ln.getTarget().getScheme())) {
+                try {
+                    PathResolver ps = new PathResolver(this, new VOSpaceAuthorizer(this));
+                    ps.validateTargetURI(ln);
+                } catch (Exception ex) {
+                    throw new UnsupportedOperationException("link to external resource", ex);
+                }
             }
         }
-
+        
         // this is a complicated way to get the Path
         LocalServiceURI loc = new LocalServiceURI(getResourceID());
         VOSURI vu = loc.getURI(node);

--- a/cavern/src/main/java/org/opencadc/cavern/nodes/NodeUtil.java
+++ b/cavern/src/main/java/org/opencadc/cavern/nodes/NodeUtil.java
@@ -236,7 +236,7 @@ class NodeUtil {
                 if ("file".equals(target.getScheme())) {
                     // link to external filesystem object
                     String path = target.getPath();
-                    log.warn("[create] external link: " + np + "\ntarget: " + target + "\nabs: " + path);
+                    log.debug("[create] external link: " + np + "\ntarget: " + target + "\nabs: " + path);
                     ret = Files.createSymbolicLink(np, root.getFileSystem().getPath(path));
                 } else {
                     String targPath = ln.getTarget().getPath().substring(1);
@@ -443,7 +443,7 @@ class NodeUtil {
         }
         VOSURI destWithName = new VOSURI(URI.create(destDir.toString() + "/" + destName));
         Path destPath = nodeToPath(root, destWithName);
-        log.warn("atomic move: " + sourcePath + " -> " + destPath);
+        log.debug("atomic move: " + sourcePath + " -> " + destPath);
         try {
             Files.move(sourcePath, destPath, StandardCopyOption.ATOMIC_MOVE);
         } catch (AtomicMoveNotSupportedException atomicMoveNotSupportedException) {
@@ -508,24 +508,24 @@ class NodeUtil {
             Path tp = Files.readSymbolicLink(p);
             Path abs = p.getParent().resolve(tp);
             Path rel = root.relativize(abs);
-            log.warn("[pathToNode] link: " +  p + "\ntarget: " + tp
+            log.debug("[pathToNode] link: " +  p + "\ntarget: " + tp
                 + "\nabs: " + abs
                 + "\nrel: " + rel);
             if (!abs.startsWith(root)) {
                 // absolute link to an additional mounted filesystem (double slash: omit host from URI)
                 URI turi = URI.create("file://" + abs.toString());
-                log.warn("[pathToNode] link: " + abs + " -> " + turi);
+                log.debug("[pathToNode] link: " + abs + " -> " + turi);
                 ret = new LinkNode(p.getFileName().toString(), turi);
             } else if (!rel.startsWith("..")) {
                 // link inside vos filesystem
                 URI turi = URI.create(rootURI.getScheme() + "://"
                     + rootURI.getAuthority() + "/" + rel.toString());
-                log.warn("[pathToNode] link: " + abs + " -> " + turi);
+                log.debug("[pathToNode] link: " + abs + " -> " + turi);
                 ret = new LinkNode(p.getFileName().toString(), turi);
             } else {
                 // relative link to target outside the vos filesystem
                 URI turi = URI.create("file://" + tp.toString());
-                log.warn("[pathToNode] external relative link: " + abs + " -> " + turi);
+                log.debug("[pathToNode] external relative link: " + abs + " -> " + turi);
                 ret = new LinkNode(p.getFileName().toString(), turi);
             }
         } else {

--- a/cavern/src/main/java/org/opencadc/cavern/nodes/NodeUtil.java
+++ b/cavern/src/main/java/org/opencadc/cavern/nodes/NodeUtil.java
@@ -112,6 +112,8 @@ import org.opencadc.vospace.Node;
 import org.opencadc.vospace.NodeProperty;
 import org.opencadc.vospace.VOS;
 import org.opencadc.vospace.VOSURI;
+import org.opencadc.vospace.server.PathResolver;
+import org.opencadc.vospace.server.auth.VOSpaceAuthorizer;
 
 /**
  * Utility methods for interacting with nodes. This is now like a DAO class
@@ -230,12 +232,20 @@ class NodeUtil {
             } else if (node instanceof LinkNode) {
                 log.debug("[create] link: " + np);
                 LinkNode ln = (LinkNode) node;
-                String targPath = ln.getTarget().getPath().substring(1);
-                Path absPath = root.resolve(targPath);
-                Path rel = np.getParent().relativize(absPath);
-                log.debug("[create] link: " + np + "\ntarget: " + targPath
-                        + "\nabs: " + absPath + "\nrel: " + rel);
-                ret = Files.createSymbolicLink(np, rel);
+                URI target = ln.getTarget();
+                if ("file".equals(target.getScheme())) {
+                    // link to external filesystem object
+                    String path = target.getPath();
+                    log.warn("[create] external link: " + np + "\ntarget: " + target + "\nabs: " + path);
+                    ret = Files.createSymbolicLink(np, root.getFileSystem().getPath(path));
+                } else {
+                    String targPath = ln.getTarget().getPath().substring(1);
+                    Path absPath = root.resolve(targPath);
+                    Path rel = np.getParent().relativize(absPath);
+                    log.debug("[create] link: " + np + "\ntarget: " + targPath
+                            + "\nabs: " + absPath + "\nrel: " + rel);
+                    ret = Files.createSymbolicLink(np, rel);
+                }
             } else {
                 throw new UnsupportedOperationException(
                         "unexpected node type: " + node.getClass().getName());


### PR DESCRIPTION
Use file:///path/to/something for an external file (external to cavern root)

allow GET and PUT (create) external file links
reject all attempts to navigate external links (to directories)
reject download of an external file via files or transfer neg.

one optional create + get test added
currently no automated tests of the reject scenarios... TBD