### PR TITLE
cavern-0.8.0 : fix init of allocationParents

### DIFF
--- a/cavern/VERSION
+++ b/cavern/VERSION
@@ -1,6 +1,6 @@
 ## deployable containers have a semantic and build tag
 # semantic version tag: major.minor
 # build version tag: timestamp
-VER=0.7.14
+VER=0.8.0
 TAGS="${VER} ${VER}-$(date -u +"%Y%m%dT%H%M%S")"
 unset VER

--- a/cavern/src/main/java/org/opencadc/cavern/nodes/FileSystemNodePersistence.java
+++ b/cavern/src/main/java/org/opencadc/cavern/nodes/FileSystemNodePersistence.java
@@ -210,11 +210,14 @@ public class FileSystemNodePersistence implements NodePersistence {
                     if (cn == null) {
                         cn = new ContainerNode(ap);
                         cn.parent = root;
+                        // set default permissions at create
+                        cn.isPublic = false;
+                        cn.inheritPermissions = false;
                         str = "created/";
                     }
-                    cn.isPublic = true;
+                    // allow change of cavern admin user in config
+                    // bug: this currently doesn't work (put does not chown)
                     cn.owner = root.owner;
-                    cn.inheritPermissions = false;
                     put(cn);
                     allocationParents.add(cn);
                     log.info(str + "loaded allocationParent: /" + cn.getName());


### PR DESCRIPTION
only set permissions when creating and use safest default values