### PR TITLE
feat: allow api key for cavern user allocation access

### DIFF
--- a/cadc-vos-server/build.gradle
+++ b/cadc-vos-server/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 11
 
 group = 'org.opencadc'
 
-version = '2.0.20'
+version = '2.0.21'
 
 description = 'OpenCADC VOSpace server'
 def git_url = 'https://github.com/opencadc/vos'
@@ -32,7 +32,7 @@ dependencies {
     implementation 'org.opencadc:cadc-uws-server:[1.2.20,)'
     implementation 'org.opencadc:cadc-cdp:[1.2.3,)'
     implementation 'org.opencadc:cadc-registry:[1.7,2.0)'
-    implementation 'org.opencadc:cadc-gms:[1.0.5,2.0)'
+    implementation 'org.opencadc:cadc-gms:[1.0.16,2.0)'
     implementation 'org.opencadc:cadc-pkg-server:[1.2.3,)'
 
     testImplementation 'junit:junit:4.13.1'

--- a/cadc-vos-server/src/main/java/org/opencadc/vospace/server/NodePersistence.java
+++ b/cadc-vos-server/src/main/java/org/opencadc/vospace/server/NodePersistence.java
@@ -69,10 +69,13 @@
 
 package org.opencadc.vospace.server;
 
+import ca.nrc.cadc.auth.AuthenticationUtil;
 import ca.nrc.cadc.io.ResourceIterator;
 import ca.nrc.cadc.net.TransientException;
 import java.net.URI;
+import java.security.Principal;
 import java.util.Set;
+import javax.security.auth.Subject;
 import org.opencadc.vospace.ContainerNode;
 import org.opencadc.vospace.Node;
 import org.opencadc.vospace.NodeNotSupportedException;
@@ -130,6 +133,27 @@ public interface NodePersistence {
      * @return set of immutable property keys
      */
     public Set<URI> getImmutableProps();
+
+    /**
+     * Get the default value of a Node Property.  This will likely be used by create operations when values are missing.
+     * @param propertyKey   The URI of the property key to get the default value for.
+     * @return  String default value for the given property key, or null if no default value is set.
+     */
+    String getDefaultPropertyValue(final URI propertyKey);
+
+    /**
+     * Check if the given caller can administer allocations.  Used by create operations.
+     * @param caller    The caller subject, used to check permissions.
+     * @return  True if the given caller can create new administer new allocations, false otherwise.
+     */
+    boolean isAdmin(Subject caller);
+
+    /**
+     * Get the admin grant for the given caller. This is used to log the specific API Key call.
+     * @param caller    The caller subject, used to pull the token.
+     * @return  String grant, or null if not applicable or not available.
+     */
+    String getAdminGrant(Subject caller);
 
     /**
      * Get the views supported by this node persistence implementation.

--- a/cadc-vos-server/src/main/java/org/opencadc/vospace/server/Utils.java
+++ b/cadc-vos-server/src/main/java/org/opencadc/vospace/server/Utils.java
@@ -235,30 +235,11 @@ public class Utils {
             }
         }
         // clear if not admin
-        if (!aps.isEmpty() && !isAdmin(caller, nodePersistence)) {
+        if (!aps.isEmpty() && !nodePersistence.isAdmin(caller)) {
             log.debug("Not admin - cleared admin props");
             aps.clear();
         }
         log.debug("Admin props " + aps.size());
         return aps;
-    }
-
-    // needed by create
-    public static boolean isAdmin(Subject caller, NodePersistence nodePersistence) {
-        if (caller == null || caller.getPrincipals().isEmpty()) {
-            return false;
-        }
-
-        ContainerNode root = nodePersistence.getRootNode();
-        for (Principal owner : root.owner.getPrincipals()) {
-            for (Principal p : caller.getPrincipals()) {
-                if (AuthenticationUtil.equals(owner, p)) {
-                    return true;
-                }
-            }
-        }
-
-        // TODO: also check admin group(s) aka root.getReadWriteGroup() membership
-        return false;
     }
 }

--- a/cadc-vos-server/src/main/java/org/opencadc/vospace/server/actions/UpdateNodeAction.java
+++ b/cadc-vos-server/src/main/java/org/opencadc/vospace/server/actions/UpdateNodeAction.java
@@ -124,7 +124,7 @@ public class UpdateNodeAction extends NodeAction {
         Subject caller = AuthenticationUtil.getCurrentSubject();
         if (serverNode instanceof ContainerNode 
                 && nodePersistence.isAllocation((ContainerNode) serverNode) 
-                && Utils.isAdmin(caller, nodePersistence)) {
+                && nodePersistence.isAdmin(caller)) {
             // allow admin to update node properties: quota
             log.debug("write permission granted to admin " + caller);
         } else if (!voSpaceAuthorizer.hasSingleNodeWritePermission(serverNode, caller)) {

--- a/cadc-vos-server/src/test/java/org/opencadc/vospace/server/auth/VOSpaceAuthorizerTest.java
+++ b/cadc-vos-server/src/test/java/org/opencadc/vospace/server/auth/VOSpaceAuthorizerTest.java
@@ -213,6 +213,28 @@ public class VOSpaceAuthorizerTest {
             return Utils.getPath(allocParentNode).equals(Utils.getPath(node.parent));
         }
 
+        /**
+         * Check if the given caller can administer allocations.  Used by create operations.
+         *
+         * @param caller The caller subject, used to check permissions.
+         * @return True if the given caller can create new administer new allocations, false otherwise.
+         */
+        @Override
+        public boolean isAdmin(Subject caller) {
+            return false;
+        }
+
+        /**
+         * Get the admin grant for the given caller. This is used to log the specific API Key call.
+         *
+         * @param caller The caller subject, used to pull the token.
+         * @return String grant, or null if not applicable or not available.
+         */
+        @Override
+        public String getAdminGrant(Subject caller) {
+            return null;
+        }
+
         // methods below are not used/implemented
         @Override
         public Set<URI> getAdminProps() {
@@ -231,6 +253,17 @@ public class VOSpaceAuthorizerTest {
 
         @Override
         public Set<URI> getImmutableProps() {
+            return null;
+        }
+
+        /**
+         * Get the default value of a Node Property.  This will likely be used by create operations when values are missing.
+         *
+         * @param propertyKey The URI of the property key to get the default value for.
+         * @return String default value for the given property key, or null if no default value is set.
+         */
+        @Override
+        public String getDefaultPropertyValue(URI propertyKey) {
             return null;
         }
 

--- a/cavern/VERSION
+++ b/cavern/VERSION
@@ -1,6 +1,6 @@
 ## deployable containers have a semantic and build tag
 # semantic version tag: major.minor
 # build version tag: timestamp
-VER=0.8.3
+VER=0.8.4
 TAGS="${VER} ${VER}-$(date -u +"%Y%m%dT%H%M%S")"
 unset VER

--- a/cavern/build.gradle
+++ b/cavern/build.gradle
@@ -35,11 +35,11 @@ dependencies {
     implementation 'org.opencadc:cadc-uws:[1.0.3,)'
     implementation 'org.opencadc:cadc-uws-server:[1.2.20,)'
     implementation 'org.opencadc:cadc-cdp:[1.0,)'
-    implementation 'org.opencadc:cadc-gms:[1.0.14,)'
+    implementation 'org.opencadc:cadc-gms:[1.0.16,)'
     implementation 'org.opencadc:cadc-dali:[1.0,)'
     implementation 'org.opencadc:cadc-pkg-server:[1.2.3,)'
     implementation 'org.opencadc:cadc-vos:[2.0.9,)'
-    implementation 'org.opencadc:cadc-vos-server:[2.0.20,)'
+    implementation 'org.opencadc:cadc-vos-server:[2.0.21,)'
 
     runtimeOnly 'org.opencadc:cadc-access-control-identity:[1.2.0,)'
 


### PR DESCRIPTION
# Description
Allow an `api-key` Authorization header when performing a User Allocation administrative task.  Also ensure a default quota is set on new allocations.

# Changes
- Log grant (client application) that requested use of API Key
- Expose new configuration from the NodePersistence for caller checking
- Assume root node owner for calls to directory creation when authenticated with API key.