### PR TITLE
cavern 0.8.4: update dependencies and add packages to log

### DIFF
--- a/cavern/VERSION
+++ b/cavern/VERSION
@@ -1,6 +1,6 @@
 ## deployable containers have a semantic and build tag
 # semantic version tag: major.minor
 # build version tag: timestamp
-VER=0.8.3
+VER=0.8.4
 TAGS="${VER} ${VER}-$(date -u +"%Y%m%dT%H%M%S")"
 unset VER

--- a/cavern/build.gradle
+++ b/cavern/build.gradle
@@ -35,9 +35,9 @@ dependencies {
     implementation 'org.opencadc:cadc-uws:[1.0.3,)'
     implementation 'org.opencadc:cadc-uws-server:[1.2.20,)'
     implementation 'org.opencadc:cadc-cdp:[1.0,)'
-    implementation 'org.opencadc:cadc-gms:[1.0.14,)'
+    implementation 'org.opencadc:cadc-gms:[1.0.16,)'
     implementation 'org.opencadc:cadc-dali:[1.0,)'
-    implementation 'org.opencadc:cadc-pkg-server:[1.2.3,)'
+    implementation 'org.opencadc:cadc-pkg-server:[1.2.5,)'
     implementation 'org.opencadc:cadc-vos:[2.0.9,)'
     implementation 'org.opencadc:cadc-vos-server:[2.0.20,)'
 

--- a/cavern/src/main/webapp/WEB-INF/web.xml
+++ b/cavern/src/main/webapp/WEB-INF/web.xml
@@ -27,6 +27,8 @@
             <param-value>
             org.opencadc.cavern
             org.opencadc.vospace
+            org.opencadc.auth
+            org.opencadc.gms
             ca.nrc.cadc.db.version
             ca.nrc.cadc.rest
             ca.nrc.cadc.vosi


### PR DESCRIPTION
CI will fail until cadc-gms is published