### PR TITLE
feat: initial configuration for permissions client

### DIFF
--- a/cavern/build.gradle
+++ b/cavern/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.opencadc:cadc-util-fs:[1.1.2,)'
     implementation 'org.opencadc:cadc-log:[1.0,)'
     implementation 'org.opencadc:cadc-permissions:[0.3.3,)'
+    implementation 'org.opencadc:cadc-permissions-client:[0.3.3,)'
     implementation 'org.opencadc:cadc-registry:[1.9.0,)'
     implementation 'org.opencadc:cadc-vosi:[1.4.3,)'
     implementation 'org.opencadc:cadc-rest:[1.3.18,)'

--- a/cavern/src/main/java/org/opencadc/cavern/CavernConfig.java
+++ b/cavern/src/main/java/org/opencadc/cavern/CavernConfig.java
@@ -126,6 +126,8 @@ public class CavernConfig {
     private final URI resourceID;
     private final List<String> allocationParents = new ArrayList<>();
 
+    // Configuration for Permissions API Client
+    private final PermissionsClientConfig permissionsClientConfig;
     private final List<String> adminAPIKeys = new ArrayList<>();
 
     // Default quota in bytes for new allocations, if not specified in the allocation request.
@@ -148,6 +150,8 @@ public class CavernConfig {
             throw new IllegalStateException("CONFIG: file not found or no properties found in file - "
                     + CAVERN_PROPERTIES);
         }
+
+        this.permissionsClientConfig = PermissionsClientConfig.fromProperties(this.mvp, CAVERN_KEY);
 
         StringBuilder sb = new StringBuilder();
         sb.append("CONFIG: incomplete/invalid: ");
@@ -223,6 +227,14 @@ public class CavernConfig {
     public Map<String, String> getAdminAPIKeys() {
         return this.adminAPIKeys.stream().map(apiKey -> apiKey.split(":")).collect(
             Collectors.toMap(splitKey -> splitKey[0], splitKey -> splitKey[1]));
+    }
+
+    /**
+     * Obtain the configuration to connect to a Permissions Client.
+     * @return  PermissionsClientConfig
+     */
+    public PermissionsClientConfig getPermissionsClientConfig() {
+        return this.permissionsClientConfig;
     }
 
     public Path getSecrets() {

--- a/cavern/src/main/java/org/opencadc/cavern/PermissionsClientConfig.java
+++ b/cavern/src/main/java/org/opencadc/cavern/PermissionsClientConfig.java
@@ -1,0 +1,93 @@
+package org.opencadc.cavern;
+
+import ca.nrc.cadc.util.MultiValuedProperties;
+import ca.nrc.cadc.util.StringUtil;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+
+public class PermissionsClientConfig {
+    private static final String PREFIX = ".permissions";
+    private static final String PERMISSIONS_API_BASE_URL = PREFIX + ".baseUrl";
+    private static final String PERMISSIONS_API_AUTH_BASE_URL = PREFIX + ".authBaseUrl";
+    private static final String PERMISSIONS_API_SERVICE_NAME = PREFIX + ".serviceName";
+    private static final String PERMISSIONS_API_AUTHORISE_TYPE = PREFIX + ".authoriseType";
+    private static final String PERMISSIONS_API_ROUTE = PREFIX + ".route";
+    private static final String PERMISSIONS_API_VERSION = PREFIX + ".version";
+    private static final String PERMISSIONS_API_METHOD = PREFIX + ".method";
+
+    private final String configPrefix;
+
+    private final String permissionsApiBaseUrl;
+    private final String permissionsApiAuthBaseUrl;
+    private final String serviceName;
+    private final String authoriseType;
+    private final String routePath;
+    private final String version;
+    private final String method;
+
+    /**
+     * Read in the configuration from properties.  This will be NULL if no base URL is set (presumed to not be
+     * configured for this Cavern instance).
+     * @param properties    The MultiValuedProperties instance.
+     * @param configPrefix  The cavern prefix to look in the config file.
+     * @return  PermissionsClientConfig instance, or null if not configured.
+     */
+    public static PermissionsClientConfig fromProperties(final MultiValuedProperties properties, final String configPrefix) {
+        final String baseUrl = properties.getFirstPropertyValue(configPrefix + PERMISSIONS_API_BASE_URL);
+        return StringUtil.hasText(baseUrl)
+                ? new PermissionsClientConfig(properties, configPrefix)
+                : null;
+    }
+
+    private PermissionsClientConfig(final MultiValuedProperties properties, final String configPrefix) {
+        this.configPrefix = configPrefix;
+
+        this.permissionsApiBaseUrl = properties.getFirstPropertyValue(configPrefix + PERMISSIONS_API_BASE_URL);
+        this.permissionsApiAuthBaseUrl = properties.getFirstPropertyValue(configPrefix + PERMISSIONS_API_AUTH_BASE_URL);
+        this.serviceName = properties.getFirstPropertyValue(configPrefix + PERMISSIONS_API_SERVICE_NAME);
+        this.authoriseType = properties.getFirstPropertyValue(configPrefix + PERMISSIONS_API_AUTHORISE_TYPE);
+        this.routePath = properties.getFirstPropertyValue(configPrefix + PERMISSIONS_API_ROUTE);
+        this.version = properties.getFirstPropertyValue(configPrefix + PERMISSIONS_API_VERSION);
+        this.method = properties.getFirstPropertyValue(configPrefix + PERMISSIONS_API_METHOD);
+    }
+
+    public URL getPermissionsApiBaseUrl() {
+        try {
+            return URI.create(this.permissionsApiBaseUrl).toURL();
+        } catch (MalformedURLException malformedURLException) {
+            throw new IllegalStateException("Invalid URL for " + this.configPrefix + PERMISSIONS_API_BASE_URL + ": "
+                    + this.permissionsApiBaseUrl, malformedURLException);
+        }
+    }
+
+    public URL getPermissionsApiAuthBaseUrl() {
+        try {
+            return URI.create(this.permissionsApiAuthBaseUrl).toURL();
+        } catch (MalformedURLException malformedURLException) {
+            throw new IllegalStateException("Invalid URL for " + this.configPrefix + PERMISSIONS_API_AUTH_BASE_URL + ": "
+                    + this.permissionsApiAuthBaseUrl, malformedURLException);
+        }
+    }
+
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    public String getAuthoriseType() {
+        return authoriseType;
+    }
+
+    public String getRoutePath() {
+        return routePath;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public String getMethod() {
+        return method;
+    }
+}

--- a/cavern/src/main/java/org/opencadc/cavern/PermissionsClientConfig.java
+++ b/cavern/src/main/java/org/opencadc/cavern/PermissionsClientConfig.java
@@ -2,7 +2,6 @@ package org.opencadc.cavern;
 
 import ca.nrc.cadc.util.MultiValuedProperties;
 import ca.nrc.cadc.util.StringUtil;
-
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
@@ -34,7 +33,7 @@ public class PermissionsClientConfig {
      * @param configPrefix  The cavern prefix to look in the config file.
      * @return  PermissionsClientConfig instance, or null if not configured.
      */
-    public static PermissionsClientConfig fromProperties(final MultiValuedProperties properties, final String configPrefix) {
+    static PermissionsClientConfig fromProperties(final MultiValuedProperties properties, final String configPrefix) {
         final String baseUrl = properties.getFirstPropertyValue(configPrefix + PERMISSIONS_API_BASE_URL);
         return StringUtil.hasText(baseUrl)
                 ? new PermissionsClientConfig(properties, configPrefix)

--- a/cavern/src/main/java/org/opencadc/cavern/nodes/PosixIdentityManager.java
+++ b/cavern/src/main/java/org/opencadc/cavern/nodes/PosixIdentityManager.java
@@ -67,11 +67,13 @@
 
 package org.opencadc.cavern.nodes;
 
-import ca.nrc.cadc.auth.AuthorizationTokenPrincipal;
+import ca.nrc.cadc.auth.AuthenticationUtil;
+import ca.nrc.cadc.auth.AuthorizationToken;
 import ca.nrc.cadc.auth.IdentityManager;
 import ca.nrc.cadc.auth.NotAuthenticatedException;
 import ca.nrc.cadc.auth.PosixPrincipal;
 import ca.nrc.cadc.util.InvalidConfigException;
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.util.Map;
@@ -82,7 +84,11 @@ import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import javax.security.auth.Subject;
 import org.apache.log4j.Logger;
+import org.json.JSONObject;
 import org.opencadc.cavern.CavernConfig;
+import org.opencadc.cavern.PermissionsClientConfig;
+import org.opencadc.permissions.client.srcnet.AuthorisationResult;
+import org.opencadc.permissions.client.srcnet.PermissionsAPIClient;
 import org.opencadc.vospace.server.NodePersistence;
 
 /**
@@ -212,37 +218,54 @@ public class PosixIdentityManager implements IdentityManager {
             // delegate to the configured IdentityManager
             final Subject validatedSubject = this.wrappedIdentityManager.validate(subject);
 
-            final Set<AuthorizationTokenPrincipal> tokenPrincipals = validatedSubject.getPrincipals(AuthorizationTokenPrincipal.class);
-            for (final AuthorizationTokenPrincipal tokenPrincipal : tokenPrincipals) {
-                final String tokenHeaderValue = tokenPrincipal.getHeaderValue();
-                final String[] parts = tokenHeaderValue.split(" ", 2);
-                if (parts.length == 2) {
-                    final String challengeType = parts[0];
-                    if (CavernConfig.ALLOCATION_API_KEY_HEADER_CHALLENGE_TYPE.equalsIgnoreCase(challengeType)) {
-                        final String tokenValue = parts[1].trim();
-                        final String[] tokenValueParts = tokenValue.split(":", 2);
-                        if (tokenValueParts.length == 2) {
-                            final String clientApplicationName = tokenValueParts[0].trim();
-                            final String apiKeyToken = tokenValueParts[1].trim();
-                            try {
-                                Context ctx = new InitialContext();
-                                FileSystemNodePersistence fileSystemNodePersistence = 
-                                        (FileSystemNodePersistence) ctx.lookup(PosixIdentityManager.JNDI_NODE_PERSISTENCE_PROPERTY);
-                                CavernConfig config = fileSystemNodePersistence.getConfig();
-                                Map<String, String> apiKeys = config.getAdminAPIKeys();
+            try {
+                Context ctx = new InitialContext();
+                FileSystemNodePersistence fileSystemNodePersistence =
+                        (FileSystemNodePersistence) ctx.lookup(PosixIdentityManager.JNDI_NODE_PERSISTENCE_PROPERTY);
+                final CavernConfig config = fileSystemNodePersistence.getConfig();
+                final PermissionsClientConfig permissionsClientConfig = config.getPermissionsClientConfig();
+                // Permissions Client was configured.
+                if (permissionsClientConfig != null) {
+                    log.debug("permissions client config is present, validating permissions API token if present");
+                    final PermissionsAPIClient permissionsAPIClient =
+                            new PermissionsAPIClient(permissionsClientConfig.getPermissionsApiBaseUrl(),
+                                    permissionsClientConfig.getPermissionsApiAuthBaseUrl());
+                    switch (permissionsClientConfig.getAuthoriseType().toLowerCase()) {
+                        case "plugin": {
+                            AuthorisationResult pluginResult = permissionsAPIClient.authorisePlugin(
+                                    permissionsClientConfig.getServiceName(),
+                                    getAuthorizationToken(validatedSubject).getCredentials(),
+                                    new JSONObject(),
+                                    permissionsClientConfig.getVersion());
 
-                                if (apiKeys.containsKey(clientApplicationName) && apiKeys.get(clientApplicationName).equals(apiKeyToken)) {
-                                    log.info("CAVERN ADMIN GRANT: " + clientApplicationName);
-                                    return fileSystemNodePersistence.getRootNode().owner;
-                                }
-                            } catch (NamingException namingException) {
-                                throw new IllegalStateException(namingException.getMessage(), namingException);
+                            if (pluginResult.isAuthorised) {
+                                log.info("CAVERN ADMIN GRANT: " + permissionsClientConfig.getServiceName());
+                                return fileSystemNodePersistence.getRootNode().owner;
                             }
+                            break;
                         }
-                        // intentionally vague error message for failed admin-api-key
-                        throw new NotAuthenticatedException("invalid token");
+                        case "route": {
+                            AuthorisationResult result = permissionsAPIClient.authoriseRoute(
+                                    permissionsClientConfig.getServiceName(),
+                                    getAuthorizationToken(validatedSubject).getCredentials(),
+                                    permissionsClientConfig.getRoutePath(),
+                                    permissionsClientConfig.getMethod(),
+                                    new JSONObject(),
+                                    permissionsClientConfig.getVersion());
+
+                            if (result.isAuthorised) {
+                                log.info("CAVERN ADMIN GRANT: " + permissionsClientConfig.getServiceName());
+                                return fileSystemNodePersistence.getRootNode().owner;
+                            }
+                            break;
+                        }
+                        default: {
+                            log.warn("invalid authoriseType in permissions client config: " + permissionsClientConfig.getAuthoriseType());
+                        }
                     }
                 }
+            } catch (NamingException | IOException exception) {
+                throw new IllegalStateException(exception.getMessage(), exception);
             }
 
             return validatedSubject;
@@ -252,15 +275,17 @@ public class PosixIdentityManager implements IdentityManager {
         return null;
     }
 
-    private Map<String, String> getAdminAPIKeys() {
-        try {
-            final Context ctx = new InitialContext();
-            final FileSystemNodePersistence fileSystemNodePersistence = (FileSystemNodePersistence) ctx.lookup("cavern-" + NodePersistence.class.getName());
-            final CavernConfig config = fileSystemNodePersistence.getConfig();
-            return config.getAdminAPIKeys();
-        } catch (NamingException namingException) {
-            throw new IllegalStateException(namingException.getMessage(), namingException);
-        }
+    /**
+     * Obtain the given Subject's bearer token. Null if none found.,
+     *
+     * @param subject The Subject to look through.
+     * @return AuthorizationToken with type "Bearer", or null if none found.
+     */
+    public static AuthorizationToken getAuthorizationToken(final Subject subject) {
+        return subject.getPublicCredentials(AuthorizationToken.class).stream()
+                .filter(token -> AuthenticationUtil.CHALLENGE_TYPE_BEARER.equalsIgnoreCase(token.getType()))
+                .findFirst()
+                .orElse(null);
     }
 
     @Override

--- a/cavern/src/main/java/org/opencadc/cavern/nodes/PosixIdentityManager.java
+++ b/cavern/src/main/java/org/opencadc/cavern/nodes/PosixIdentityManager.java
@@ -245,7 +245,7 @@ public class PosixIdentityManager implements IdentityManager {
                             break;
                         }
                         case "route": {
-                            AuthorisationResult result = permissionsAPIClient.authoriseRoute(
+                            AuthorisationResult routeResult = permissionsAPIClient.authoriseRoute(
                                     permissionsClientConfig.getServiceName(),
                                     getAuthorizationToken(validatedSubject).getCredentials(),
                                     permissionsClientConfig.getRoutePath(),
@@ -253,7 +253,7 @@ public class PosixIdentityManager implements IdentityManager {
                                     new JSONObject(),
                                     permissionsClientConfig.getVersion());
 
-                            if (result.isAuthorised) {
+                            if (routeResult.isAuthorised) {
                                 log.info("CAVERN ADMIN GRANT: " + permissionsClientConfig.getServiceName());
                                 return fileSystemNodePersistence.getRootNode().owner;
                             }

--- a/cavern/src/main/java/org/opencadc/cavern/nodes/PosixIdentityManager.java
+++ b/cavern/src/main/java/org/opencadc/cavern/nodes/PosixIdentityManager.java
@@ -260,7 +260,8 @@ public class PosixIdentityManager implements IdentityManager {
                             break;
                         }
                         default: {
-                            log.warn("invalid authoriseType in permissions client config: " + permissionsClientConfig.getAuthoriseType());
+                            log.warn("invalid authoriseType in permissions client config: "
+                                    + permissionsClientConfig.getAuthoriseType());
                         }
                     }
                 }


### PR DESCRIPTION
# Changes (2026.05.05)
- Added configuration logic to load from existing `cavern.properties`
  - Kept configuration to its own object to keep isolated