### PR TITLE
Cavern papi support alt - refactored into cadc-vos-server

### DIFF
--- a/cadc-test-vos/build.gradle
+++ b/cadc-test-vos/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 11
 
 group = 'org.opencadc'
 
-version = '2.1.14'
+version = '2.1.15'
 
 description = 'OpenCADC VOSpace test library'
 def git_url = 'https://github.com/opencadc/vos'

--- a/cadc-test-vos/src/main/java/org/opencadc/conformance/vos/VOSTest.java
+++ b/cadc-test-vos/src/main/java/org/opencadc/conformance/vos/VOSTest.java
@@ -139,18 +139,24 @@ public abstract class VOSTest {
 
     @Before
     public void initTestContainer() throws Exception {
-        String name = rootTestFolderName;
-        ContainerNode testNode = new ContainerNode(name);
-        testNode.isPublic = true;
-        testNode.inheritPermissions = false;
+        // subclass may have put a relative path here, eg home/int-tests
+        ContainerNode parent = null;
+        String[] pth = rootTestFolderName.split("/");
+        for (String name : pth) {
+            ContainerNode testNode = new ContainerNode(name);
+            testNode.isPublic = true;
+            testNode.inheritPermissions = false;
+            testNode.parent = parent;
 
-        URL nodeURL = getNodeURL(nodesServiceURL, null); // method already puts test folder name in
-        VOSURI nodeURI = getVOSURI(null);
-        NodeReader.NodeReaderResult result = get(nodeURL, 200, XML_CONTENT_TYPE, false);
-        if (result == null) {
-            put(nodeURL, nodeURI, testNode);
-        } else {
-            post(nodeURL, nodeURI, testNode);
+            URL nodeURL = getNodeURL(nodesServiceURL, null); // method already puts test folder name in
+            VOSURI nodeURI = getVOSURI(null);
+            NodeReader.NodeReaderResult result = get(nodeURL, 200, XML_CONTENT_TYPE, false);
+            if (result == null) {
+                put(nodeURL, nodeURI, testNode);
+            } else {
+                post(nodeURL, nodeURI, testNode);
+            }
+            parent = testNode;
         }
     }
     
@@ -259,7 +265,7 @@ public abstract class VOSTest {
         HttpPost post = new HttpPost(nodeURL, content, true);
         log.debug("POST: " + nodeURL);
         Subject.doAs(authSubject, new RunnableAction(post));
-        log.debug("POST responseCode: " + post.getResponseCode() + " " + post.getThrowable());
+        log.info("POST responseCode: " + post.getResponseCode() + " " + post.getThrowable());
         if (!verify && post.getResponseCode() == 404) {
             return;
         }

--- a/cadc-vos-server/build.gradle
+++ b/cadc-vos-server/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 11
 
 group = 'org.opencadc'
 
-version = '2.0.22'
+version = '2.0.23'
 
 description = 'OpenCADC VOSpace server'
 def git_url = 'https://github.com/opencadc/vos'

--- a/cadc-vos-server/src/main/java/org/opencadc/vospace/server/actions/CreateNodeAction.java
+++ b/cadc-vos-server/src/main/java/org/opencadc/vospace/server/actions/CreateNodeAction.java
@@ -174,6 +174,7 @@ public class CreateNodeAction extends NodeAction {
         // backwards compat: ignore if clients still send this, just in case
         NodeProperty creatorJWT = clientNode.getProperty(VOS.PROPERTY_URI_CREATOR_JWT);
         if (creatorJWT != null) {
+            log.warn("found obsolete " + VOS.PROPERTY_URI_CREATOR_JWT + " -- DROPPED");
             clientNode.getProperties().remove(creatorJWT);
         }
 

--- a/cadc-vos-server/src/main/java/org/opencadc/vospace/server/actions/CreateNodeAction.java
+++ b/cadc-vos-server/src/main/java/org/opencadc/vospace/server/actions/CreateNodeAction.java
@@ -3,7 +3,7 @@
  *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
  **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
  *
- *  (c) 2023.                            (c) 2023.
+ *  (c) 2026.                            (c) 2026.
  *  Government of Canada                 Gouvernement du Canada
  *  National Research Council            Conseil national de recherches
  *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -68,10 +68,13 @@
 package org.opencadc.vospace.server.actions;
 
 import ca.nrc.cadc.auth.AuthenticationUtil;
-import ca.nrc.cadc.auth.AuthorizationTokenPrincipal;
 import ca.nrc.cadc.auth.HttpPrincipal;
 import ca.nrc.cadc.auth.IdentityManager;
+import ca.nrc.cadc.net.HttpConstants;
 import ca.nrc.cadc.net.HttpTransfer;
+import java.io.IOException;
+import java.security.AccessControlException;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -124,66 +127,52 @@ public class CreateNodeAction extends NodeAction {
         if (cur != null) {
             throw NodeFault.DuplicateNode.getStatus(clientNodeURI.toString());
         }
-
+        // does not exist, parent resolved
+        clientNode.parent = parent;
+        
+        // there are 3 kinds of create node:
+        // 1. admin-allocate: admin creates a node owned by someone else, optionally assigns admin props
+        // 2. self-allocate: a user creates there own allocation
+        // 3. normal/common: a user creates a node
+        final IdentityManager im = AuthenticationUtil.getIdentityManager();
         Subject caller = AuthenticationUtil.getCurrentSubject();
-        if (!voSpaceAuthorizer.hasSingleNodeWritePermission(parent, caller)) {
+        final List<NodeProperty> allowedAdminProps;
+        Subject writePerm = caller;
+        if (Utils.isAdmin(caller, nodePersistence)) {
+            if (clientNode.ownerDisplay != null) {
+                // admin assigns owner
+                clientNode.owner = toOwnerSubject(clientNode.ownerDisplay, im);
+                if (clientNode.owner == null) {
+                    throw new RuntimeException("admin-allocate: failed to convert '" + clientNode.ownerDisplay + "' "
+                        + " to a Subject");
+                }
+            } else {
+                // admin is owner
+                clientNode.owner = caller;
+            }
+            allowedAdminProps = Utils.getAdminProps(clientNode, nodePersistence.getAdminProps(), caller, nodePersistence);
+            logInfo.setMessage("admin-allocate");
+        } else if (isSelfAllocate(caller, clientNode)) {
+            checkSelfAllocatePermission(caller, clientNodeURI);
+            clientNode.owner = caller;
+            allowedAdminProps = new ArrayList<>();
+            allowedAdminProps.add(new NodeProperty(VOS.PROPERTY_URI_CREATOR));
+            writePerm = nodePersistence.getRootNode().owner; // elevate write permission check below
+            logInfo.setMessage("self-allocate");
+        } else {
+            // normal create: caller is owner
+            clientNode.owner = caller;
+            allowedAdminProps = new ArrayList<>();
+        }
+
+        if (!voSpaceAuthorizer.hasSingleNodeWritePermission(parent, writePerm)) {
             throw NodeFault.PermissionDenied.getStatus(clientNodeURI.toString());
         }
-
-        // attempt to set owner
-        IdentityManager im = AuthenticationUtil.getIdentityManager();
-        clientNode.parent = parent;
-
-        // Ensure the caller is set.  It MAY be overridden below.
-        clientNode.owner = caller;
-
-        // Extract here to remove later.
+        // protected against accidentally using this again
+        writePerm = null;
+        
+        // backwards compat: ignore if clients still send this, just in case
         NodeProperty creatorJWT = clientNode.getProperty(VOS.PROPERTY_URI_CREATOR_JWT);
-        if (Utils.isAdmin(caller, nodePersistence)) {
-            if (creatorJWT != null && clientNode.ownerDisplay != null) {
-                // The "creator" property clashes with the "creator-jwt" property.
-                throw NodeFault.InvalidArgument.getStatus("BUG: " + VOS.PROPERTY_URI_CREATOR + " property already exists, but " + VOS.PROPERTY_URI_CREATOR_JWT
-                                                              + " is present. This should not happen.");
-            }
-
-            if (clientNode.ownerDisplay != null) {
-                // admin is allowed to assign a different owner
-                try {
-                    Subject tmp = new Subject();
-                    // HACK: known IdentityManager implementations prefer the HttpPrincipal aka
-                    // network username for toDisplayString(Subject) so that's the value that
-                    // normally gets put into node.ownerDisplay and rendered in node documents
-                    // so choosing HttpPrincipal here makes output and input (set owner) use the
-                    // same values... but seems kind of sketchy.
-                    tmp.getPrincipals().add(new HttpPrincipal(clientNode.ownerDisplay));
-                    clientNode.owner = im.augment(tmp);
-                } catch (Exception ex) {
-                    log.error("failed to map " + clientNode.ownerDisplay + " to a known user", ex);
-                    throw ex;
-                }
-            } else if (creatorJWT != null) {
-                log.debug("Creating user allocation on behalf of OIDC account.");
-                Subject nodeOwner = new Subject();
-                final String token = creatorJWT.getValue();
-                final AuthorizationTokenPrincipal authorizationTokenPrincipal = new AuthorizationTokenPrincipal(AuthenticationUtil.AUTHORIZATION_HEADER,
-                                                                                                                AuthenticationUtil.CHALLENGE_TYPE_BEARER
-                                                                                                                    + " " + token);
-
-                nodeOwner.getPrincipals().add(authorizationTokenPrincipal);
-
-                nodeOwner = AuthenticationUtil.validateSubject(nodeOwner);
-                nodeOwner = AuthenticationUtil.augmentSubject(nodeOwner);
-
-                log.debug("Setting new allocation node owner to " + im.toDisplayString(nodeOwner));
-                clientNode.owner = nodeOwner;
-                clientNode.ownerID = null; // just in case
-
-                log.debug("Creating user allocation on behalf of OIDC account: OK");
-            }
-        }
-
-        // Ensure it's always removed after being handled in the admin block.  This property is never persisted, as it's just a means to an end for the
-        // creator property.
         if (creatorJWT != null) {
             clientNode.getProperties().remove(creatorJWT);
         }
@@ -218,10 +207,6 @@ public class CreateNodeAction extends NodeAction {
                 }
             }
         }
-
-        // pick out eligible admin-only props (they are immutable to normal users)
-        final List<NodeProperty> allowedAdminProps = Utils.getAdminProps(clientNode, nodePersistence.getAdminProps(), caller,
-                nodePersistence);
         
         // sanitize input properties into clean set
         Set<NodeProperty> np = new HashSet<>();
@@ -237,8 +222,58 @@ public class CreateNodeAction extends NodeAction {
         // output modified node
         NodeWriter nodeWriter = getNodeWriter();
         syncOutput.setCode(201);
-        syncOutput.setHeader(HttpTransfer.CONTENT_TYPE, getMediaType());
+        syncOutput.setHeader(HttpConstants.HDR_CONTENT_TYPE, getMediaType());
         // TODO: should the VOSURI in the output target or actual? eg resolveLinks=true
         nodeWriter.write(localServiceURI.getURI(storedNode), storedNode, syncOutput.getOutputStream(), VOS.Detail.max);
+    }
+
+    /**
+     * Check if the caller is allowed to create a their own allocation.The uri is
+ supplied in case the permission checks need the VOSpace resourceID or the path. The default behaviour of this method is to throw an AccessControlException.
+     * 
+     * @param caller the user trying to create an allocation
+     * @param uri the vos URI of the allocation
+     * @throws AccessControlException if the caller is not allowed
+     * @throws Exception if some error prevents checking for authorisation
+     */
+    protected void checkSelfAllocatePermission(Subject caller, VOSURI uri) 
+            throws AccessControlException, Exception {
+        throw new AccessControlException("permission denied: self-allocate is not enabled");
+    }
+
+    // self-allocate: a user tries to create a ContainerNode allocation for themselves
+    private boolean isSelfAllocate(Subject caller, Node node) {
+        return node instanceof ContainerNode 
+                && nodePersistence.isAllocation((ContainerNode) node);
+    }
+    
+    private Subject toOwnerSubject(String ownerStringRep, IdentityManager im) {
+        // try IdentityManager.soSubject(Object)
+        // this could work for different principal type X IdentityManager combinations
+        try {
+            Subject ret = im.toSubject(ownerStringRep);
+            log.debug("create owner subject by im.toSubject: " + ret);
+            return ret;
+        } catch (Exception ex) {
+            log.debug("IdentityManager.toSubject() failed for " + ownerStringRep + ": " +  ex);
+        }
+
+        // HACK: known IdentityManager implementations prefer the HttpPrincipal aka
+        // network username for toDisplayString(Subject) so that's the value that
+        // normally gets put into node.ownerDisplay and rendered in node documents
+        // so choosing HttpPrincipal here makes output and input (set owner) use the
+        // same values... but seems kind of sketchy.
+        try {
+            Subject tmp = new Subject();
+            tmp.getPrincipals().add(new HttpPrincipal(ownerStringRep));
+            Subject ret = im.augment(tmp);
+            log.debug("create owner subject by im.augment(HttpPrincipal): " + ret);
+            return ret;
+        } catch (Exception ex) {
+            log.debug("IdentityManager.augment() failed for " + ownerStringRep + ": " + ex);
+        }
+        
+        // neither of those worked...
+        return null;
     }
 }

--- a/cavern/README.md
+++ b/cavern/README.md
@@ -57,8 +57,12 @@ org.opencadc.cavern.resourceID = ivo://{authority}/{name}
 # (optional) identify which container nodes are allocations
 org.opencadc.cavern.allocationParent = {top level node}
 
-# (optional) API Keys with administrative privileges.  Multiple keys can be specified, one per line.
+# (deprecated - do not use) API Keys with administrative privileges.  Multiple keys can be specified, one per line.
 # org.opencadc.cavern.adminAPIKey = {applicationClientName}:{apiKeyToken}
+
+# Specific PermissionsAPI configuration when deployed to SKAO Regional Centres.  Not for general consumption.
+# org.opencadc.cavern.papi.baseURL = https://permissions.srcnet.skao.int/api
+# org.opencadc.cavern.papi.authBaseURL = https://authn.srcnet.skao.int/api
 
 # (optional) provide a class implementing the org.opencadc.cavern.nodes.QuotaPlugin interface to control Quotas
 # for users.

--- a/cavern/build.gradle
+++ b/cavern/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.opencadc:cadc-util-fs:[1.1.2,)'
     implementation 'org.opencadc:cadc-log:[1.0,)'
     implementation 'org.opencadc:cadc-permissions:[0.3.3,)'
+    implementation 'org.opencadc:cadc-permissions-client:[0.3.3,)'
     implementation 'org.opencadc:cadc-registry:[1.9.0,)'
     implementation 'org.opencadc:cadc-vosi:[1.4.3,)'
     implementation 'org.opencadc:cadc-rest:[1.3.18,)'

--- a/cavern/src/intTest/README.md
+++ b/cavern/src/intTest/README.md
@@ -1,0 +1,14 @@
+# cavern integration tests
+
+The `intTest` target uses the cadc-etst-vos library to run tests against a locally
+deployed cavern instance. This looks up `ivo://opencadc.org/cavern` in a local `reg`
+service.
+
+The tests create and run in `/projects/int-tests`; some tests may rely on configuration
+with
+```
+org.opencadc.cavern.allocationParent = /projects
+org.opencadc.cavern.selfAllocateGroup = ivo://cadc.nrc.ca/gms?opencadc-vospace-test
+```
+where the `selfAllocateGroup` is an undocumented prototype feature.
+

--- a/cavern/src/intTest/java/org/opencadc/cavern/Constants.java
+++ b/cavern/src/intTest/java/org/opencadc/cavern/Constants.java
@@ -83,6 +83,8 @@ public abstract class Constants {
     static final File AUTH_TEST_CERT;
     static final GroupURI AUTH_TEST_GROUP;
     
+    static final String TEST_PATH = "projects/int-tests";
+    
     static {
         TEST_CERT = FileUtil.getFileFromResource("cavern-test.pem", NodesTest.class);
         AUTH_TEST_CERT = FileUtil.getFileFromResource("cavern-auth-test.pem", TransferTest.class);

--- a/cavern/src/intTest/java/org/opencadc/cavern/FilesTest.java
+++ b/cavern/src/intTest/java/org/opencadc/cavern/FilesTest.java
@@ -92,6 +92,7 @@ public class FilesTest extends org.opencadc.conformance.vos.FilesTest {
         super.enableTestDataNodePermission(Constants.AUTH_TEST_CERT);
 
         super.linkExternalFile = true;
+        super.rootTestFolderName = Constants.TEST_PATH;
     }
 
 }

--- a/cavern/src/intTest/java/org/opencadc/cavern/NodesTest.java
+++ b/cavern/src/intTest/java/org/opencadc/cavern/NodesTest.java
@@ -107,5 +107,7 @@ public class NodesTest extends org.opencadc.conformance.vos.NodesTest {
         super.enablePermissionTests(group2, groupMemberCert);
         
         super.cleanupOnSuccess = false;
+        
+        super.rootTestFolderName = Constants.TEST_PATH;
     }
 }

--- a/cavern/src/intTest/java/org/opencadc/cavern/PackageTest.java
+++ b/cavern/src/intTest/java/org/opencadc/cavern/PackageTest.java
@@ -86,7 +86,8 @@ public class PackageTest extends org.opencadc.conformance.vos.PackageTest {
     }
 
     public PackageTest() {
-            super(Constants.RESOURCE_ID, Constants.TEST_CERT, false);
+        super(Constants.RESOURCE_ID, Constants.TEST_CERT, false);
+        super.rootTestFolderName = Constants.TEST_PATH;
     }
 
 }

--- a/cavern/src/intTest/java/org/opencadc/cavern/RecursiveNodeDeleteTest.java
+++ b/cavern/src/intTest/java/org/opencadc/cavern/RecursiveNodeDeleteTest.java
@@ -105,5 +105,6 @@ public class RecursiveNodeDeleteTest extends org.opencadc.conformance.vos.Recurs
         super.enablePermissionTests(group2, groupMemberCert);
 
         super.cleanupOnSuccess = false;
+        super.rootTestFolderName = Constants.TEST_PATH;
     }
 }

--- a/cavern/src/intTest/java/org/opencadc/cavern/RecursiveNodePropsTest.java
+++ b/cavern/src/intTest/java/org/opencadc/cavern/RecursiveNodePropsTest.java
@@ -105,5 +105,6 @@ public class RecursiveNodePropsTest extends org.opencadc.conformance.vos.Recursi
         super.enablePermissionTests(group2, groupMemberCert);
 
         super.cleanupOnSuccess = false;
+        super.rootTestFolderName = Constants.TEST_PATH;
     }
 }

--- a/cavern/src/intTest/java/org/opencadc/cavern/TransferTest.java
+++ b/cavern/src/intTest/java/org/opencadc/cavern/TransferTest.java
@@ -104,6 +104,7 @@ public class TransferTest extends org.opencadc.conformance.vos.TransferTest {
 
         // enables testDataNodePermission, AUTH_TEST_CERT user is a member of AUTH_TEST_GROUP.
         super.enableTestDataNodePermission(Constants.AUTH_TEST_GROUP, Constants.AUTH_TEST_CERT);
+        super.rootTestFolderName = Constants.TEST_PATH;
     }
     
     @Test

--- a/cavern/src/main/java/org/opencadc/cavern/CavernConfig.java
+++ b/cavern/src/main/java/org/opencadc/cavern/CavernConfig.java
@@ -81,16 +81,20 @@ import java.io.File;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 import javax.security.auth.Subject;
 import org.apache.log4j.Logger;
 import org.opencadc.cavern.nodes.NoQuotaPlugin;
 import org.opencadc.cavern.nodes.QuotaPlugin;
+import org.opencadc.gms.GroupURI;
 
 public class CavernConfig {
 
@@ -113,6 +117,7 @@ public class CavernConfig {
     public static final String ROOT_OWNER_GID = CAVERN_KEY + ".filesystem.rootOwner.gid";
     
     public static final String ALLOCATION_PARENT = CAVERN_KEY + ".allocationParent";
+    public static final String SELF_ALLOCATE = CAVERN_KEY + ".selfAllocateGroup";
 
     // An API Key representing a client that has administrative access.  More than one is possible.
     // Format is <applicationClientName>:<apiKeyToken>
@@ -125,6 +130,7 @@ public class CavernConfig {
     
     private final URI resourceID;
     private final List<String> allocationParents = new ArrayList<>();
+    private final Set<GroupURI> selfAllocateGroups = new TreeSet<>();
 
     // Configuration for Permissions API Client
     private final PermissionsClientConfig permissionsClientConfig;
@@ -156,12 +162,15 @@ public class CavernConfig {
         StringBuilder sb = new StringBuilder();
         sb.append("CONFIG: incomplete/invalid: ");
 
+        // required:
         boolean resourceProp = checkProperty(mvp, sb, RESOURCE_ID, true);
         boolean baseDirProp = checkProperty(mvp, sb, FILESYSTEM_BASE_DIR, true);
         boolean subPathProp = checkProperty(mvp, sb, FILESYSTEM_SUB_PATH, true);
         boolean rootOwnerProp = checkProperty(mvp, sb, ROOT_OWNER, true);
-        boolean sshfsServerBaseProp = checkProperty(mvp, sb, SSHFS_SERVER_BASE, false);
-        boolean allocProp = checkProperty(mvp, sb, ALLOCATION_PARENT, false);
+        // optional:
+        checkProperty(mvp, sb, SSHFS_SERVER_BASE, false);
+        checkProperty(mvp, sb, ALLOCATION_PARENT, false);
+        checkProperty(mvp, sb, SELF_ALLOCATE, false);
         checkProperty(mvp, sb, QUOTA_PLUGIN_IMPLEMENTATION, false);
 
         if (!resourceProp || !baseDirProp || !subPathProp || !rootOwnerProp) {
@@ -191,6 +200,16 @@ public class CavernConfig {
             allocationParents.add(ap);
         }
 
+        for (String sag : mvp.getProperty(SELF_ALLOCATE)) {
+            try {
+                URI uri = new URI(sag);
+                GroupURI guri = new GroupURI(uri);
+                this.selfAllocateGroups.add(guri);
+            } catch (URISyntaxException ex) {
+                throw new InvalidConfigException(SELF_ALLOCATE + " = " + sag + " INVALID GroupURI");
+            }
+        }
+
         adminAPIKeys.addAll(mvp.getProperty(CavernConfig.ADMIN_API_KEY));
 
         final String configuredDefaultQuotaGB = mvp.getFirstPropertyValue(CavernConfig.DEFAULT_QUOTA_GB);
@@ -218,6 +237,10 @@ public class CavernConfig {
     
     public List<String> getAllocationParents() {
         return allocationParents;
+    }
+
+    public Set<GroupURI> getSelfAllocateGroups() {
+        return selfAllocateGroups;
     }
 
     /**

--- a/cavern/src/main/java/org/opencadc/cavern/CavernConfig.java
+++ b/cavern/src/main/java/org/opencadc/cavern/CavernConfig.java
@@ -126,6 +126,8 @@ public class CavernConfig {
     private final URI resourceID;
     private final List<String> allocationParents = new ArrayList<>();
 
+    // Configuration for Permissions API Client
+    private final PermissionsClientConfig permissionsClientConfig;
     private final List<String> adminAPIKeys = new ArrayList<>();
 
     // Default quota in bytes for new allocations, if not specified in the allocation request.
@@ -148,6 +150,8 @@ public class CavernConfig {
             throw new IllegalStateException("CONFIG: file not found or no properties found in file - "
                     + CAVERN_PROPERTIES);
         }
+
+        this.permissionsClientConfig = PermissionsClientConfig.fromProperties(this.mvp, CAVERN_KEY);
 
         StringBuilder sb = new StringBuilder();
         sb.append("CONFIG: incomplete/invalid: ");
@@ -223,6 +227,14 @@ public class CavernConfig {
     public Map<String, String> getAdminAPIKeys() {
         return this.adminAPIKeys.stream().map(apiKey -> apiKey.split(":")).collect(
             Collectors.toMap(splitKey -> splitKey[0], splitKey -> splitKey[1]));
+    }
+
+    /**
+     * Obtain the configuration to connect to a Permissions Client.
+     * @return  PermissionsClientConfig
+     */
+    public PermissionsClientConfig getPermissionsClientConfig() {
+        return this.permissionsClientConfig;
     }
 
     public Path getSecrets() {

--- a/cavern/src/main/java/org/opencadc/cavern/PermissionsClientConfig.java
+++ b/cavern/src/main/java/org/opencadc/cavern/PermissionsClientConfig.java
@@ -1,0 +1,93 @@
+package org.opencadc.cavern;
+
+import ca.nrc.cadc.util.MultiValuedProperties;
+import ca.nrc.cadc.util.StringUtil;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+
+public class PermissionsClientConfig {
+    private static final String PREFIX = ".permissions";
+    private static final String PERMISSIONS_API_BASE_URL = PREFIX + ".baseUrl";
+    private static final String PERMISSIONS_API_AUTH_BASE_URL = PREFIX + ".authBaseUrl";
+    private static final String PERMISSIONS_API_SERVICE_NAME = PREFIX + ".serviceName";
+    private static final String PERMISSIONS_API_AUTHORISE_TYPE = PREFIX + ".authoriseType";
+    private static final String PERMISSIONS_API_ROUTE = PREFIX + ".route";
+    private static final String PERMISSIONS_API_VERSION = PREFIX + ".version";
+    private static final String PERMISSIONS_API_METHOD = PREFIX + ".method";
+
+    private final String configPrefix;
+
+    private final String permissionsApiBaseUrl;
+    private final String permissionsApiAuthBaseUrl;
+    private final String serviceName;
+    private final String authoriseType;
+    private final String routePath;
+    private final String version;
+    private final String method;
+
+    /**
+     * Read in the configuration from properties.  This will be NULL if no base URL is set (presumed to not be
+     * configured for this Cavern instance).
+     * @param properties    The MultiValuedProperties instance.
+     * @param configPrefix  The cavern prefix to look in the config file.
+     * @return  PermissionsClientConfig instance, or null if not configured.
+     */
+    public static PermissionsClientConfig fromProperties(final MultiValuedProperties properties, final String configPrefix) {
+        final String baseUrl = properties.getFirstPropertyValue(configPrefix + PERMISSIONS_API_BASE_URL);
+        return StringUtil.hasText(baseUrl)
+                ? new PermissionsClientConfig(properties, configPrefix)
+                : null;
+    }
+
+    private PermissionsClientConfig(final MultiValuedProperties properties, final String configPrefix) {
+        this.configPrefix = configPrefix;
+
+        this.permissionsApiBaseUrl = properties.getFirstPropertyValue(configPrefix + PERMISSIONS_API_BASE_URL);
+        this.permissionsApiAuthBaseUrl = properties.getFirstPropertyValue(configPrefix + PERMISSIONS_API_AUTH_BASE_URL);
+        this.serviceName = properties.getFirstPropertyValue(configPrefix + PERMISSIONS_API_SERVICE_NAME);
+        this.authoriseType = properties.getFirstPropertyValue(configPrefix + PERMISSIONS_API_AUTHORISE_TYPE);
+        this.routePath = properties.getFirstPropertyValue(configPrefix + PERMISSIONS_API_ROUTE);
+        this.version = properties.getFirstPropertyValue(configPrefix + PERMISSIONS_API_VERSION);
+        this.method = properties.getFirstPropertyValue(configPrefix + PERMISSIONS_API_METHOD);
+    }
+
+    public URL getPermissionsApiBaseUrl() {
+        try {
+            return URI.create(this.permissionsApiBaseUrl).toURL();
+        } catch (MalformedURLException malformedURLException) {
+            throw new IllegalStateException("Invalid URL for " + this.configPrefix + PERMISSIONS_API_BASE_URL + ": "
+                    + this.permissionsApiBaseUrl, malformedURLException);
+        }
+    }
+
+    public URL getPermissionsApiAuthBaseUrl() {
+        try {
+            return URI.create(this.permissionsApiAuthBaseUrl).toURL();
+        } catch (MalformedURLException malformedURLException) {
+            throw new IllegalStateException("Invalid URL for " + this.configPrefix + PERMISSIONS_API_AUTH_BASE_URL + ": "
+                    + this.permissionsApiAuthBaseUrl, malformedURLException);
+        }
+    }
+
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    public String getAuthoriseType() {
+        return authoriseType;
+    }
+
+    public String getRoutePath() {
+        return routePath;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public String getMethod() {
+        return method;
+    }
+}

--- a/cavern/src/main/java/org/opencadc/cavern/PermissionsClientConfig.java
+++ b/cavern/src/main/java/org/opencadc/cavern/PermissionsClientConfig.java
@@ -7,24 +7,22 @@ import java.net.URI;
 import java.net.URL;
 
 public class PermissionsClientConfig {
-    private static final String PREFIX = ".permissions";
+    private static final String PREFIX = ".papi";
     private static final String PERMISSIONS_API_BASE_URL = PREFIX + ".baseUrl";
     private static final String PERMISSIONS_API_AUTH_BASE_URL = PREFIX + ".authBaseUrl";
-    private static final String PERMISSIONS_API_SERVICE_NAME = PREFIX + ".serviceName";
-    private static final String PERMISSIONS_API_AUTHORISE_TYPE = PREFIX + ".authoriseType";
-    private static final String PERMISSIONS_API_ROUTE = PREFIX + ".route";
-    private static final String PERMISSIONS_API_VERSION = PREFIX + ".version";
-    private static final String PERMISSIONS_API_METHOD = PREFIX + ".method";
 
     private final String configPrefix;
 
     private final String permissionsApiBaseUrl;
     private final String permissionsApiAuthBaseUrl;
-    private final String serviceName;
-    private final String authoriseType;
-    private final String routePath;
-    private final String version;
-    private final String method;
+
+    // Hard-coded values for now.
+    private final String serviceName = "canfar-api";
+    private final String authoriseType = "route";
+    private final String routePath = "/nodes/home/{username}";
+    private final String version = "1";
+    private final String method = "PUT";
+
 
     /**
      * Read in the configuration from properties.  This will be NULL if no base URL is set (presumed to not be
@@ -45,11 +43,6 @@ public class PermissionsClientConfig {
 
         this.permissionsApiBaseUrl = properties.getFirstPropertyValue(configPrefix + PERMISSIONS_API_BASE_URL);
         this.permissionsApiAuthBaseUrl = properties.getFirstPropertyValue(configPrefix + PERMISSIONS_API_AUTH_BASE_URL);
-        this.serviceName = properties.getFirstPropertyValue(configPrefix + PERMISSIONS_API_SERVICE_NAME);
-        this.authoriseType = properties.getFirstPropertyValue(configPrefix + PERMISSIONS_API_AUTHORISE_TYPE);
-        this.routePath = properties.getFirstPropertyValue(configPrefix + PERMISSIONS_API_ROUTE);
-        this.version = properties.getFirstPropertyValue(configPrefix + PERMISSIONS_API_VERSION);
-        this.method = properties.getFirstPropertyValue(configPrefix + PERMISSIONS_API_METHOD);
     }
 
     public URL getPermissionsApiBaseUrl() {

--- a/cavern/src/main/java/org/opencadc/cavern/PermissionsClientConfig.java
+++ b/cavern/src/main/java/org/opencadc/cavern/PermissionsClientConfig.java
@@ -19,7 +19,7 @@ public class PermissionsClientConfig {
     // Hard-coded values for now.
     private final String serviceName = "canfar-api";
     private final String authoriseType = "route";
-    private final String routePath = "/nodes/home/{username}";
+    private final String routePath = "/home/{username}";
     private final String version = "1";
     private final String method = "PUT";
 

--- a/cavern/src/main/java/org/opencadc/cavern/PermissionsClientConfig.java
+++ b/cavern/src/main/java/org/opencadc/cavern/PermissionsClientConfig.java
@@ -2,7 +2,6 @@ package org.opencadc.cavern;
 
 import ca.nrc.cadc.util.MultiValuedProperties;
 import ca.nrc.cadc.util.StringUtil;
-
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
@@ -34,7 +33,7 @@ public class PermissionsClientConfig {
      * @param configPrefix  The cavern prefix to look in the config file.
      * @return  PermissionsClientConfig instance, or null if not configured.
      */
-    public static PermissionsClientConfig fromProperties(final MultiValuedProperties properties, final String configPrefix) {
+    static PermissionsClientConfig fromProperties(final MultiValuedProperties properties, final String configPrefix) {
         final String baseUrl = properties.getFirstPropertyValue(configPrefix + PERMISSIONS_API_BASE_URL);
         return StringUtil.hasText(baseUrl)
                 ? new PermissionsClientConfig(properties, configPrefix)

--- a/cavern/src/main/java/org/opencadc/cavern/PermissionsClientConfig.java
+++ b/cavern/src/main/java/org/opencadc/cavern/PermissionsClientConfig.java
@@ -19,7 +19,7 @@ public class PermissionsClientConfig {
     // Hard-coded values for now.
     private final String serviceName = "canfar-api";
     private final String authoriseType = "route";
-    private final String routePath = "/home/{username}";
+    //private final String routePath = "/home/{username}";
     private final String version = "1";
     private final String method = "PUT";
 
@@ -71,9 +71,9 @@ public class PermissionsClientConfig {
         return authoriseType;
     }
 
-    public String getRoutePath() {
-        return routePath;
-    }
+    //public String getRoutePath() {
+    //    return routePath;
+    //}
 
     public String getVersion() {
         return version;

--- a/cavern/src/main/java/org/opencadc/cavern/actions/CreateNodeAction.java
+++ b/cavern/src/main/java/org/opencadc/cavern/actions/CreateNodeAction.java
@@ -5,6 +5,7 @@ import ca.nrc.cadc.auth.AuthorizationToken;
 import ca.nrc.cadc.util.InvalidConfigException;
 import java.security.AccessControlException;
 import java.security.PrivilegedExceptionAction;
+import java.util.Objects;
 import javax.security.auth.Subject;
 import org.json.JSONObject;
 import org.opencadc.cavern.CavernConfig;
@@ -22,65 +23,69 @@ import org.opencadc.vospace.Node;
 public class CreateNodeAction extends org.opencadc.vospace.server.actions.CreateNodeAction {
     @Override
     public void doAction() throws Exception {
-            final FileSystemNodePersistence fileSystemNodePersistence = getFileSystemNodePersistence();
-            final Subject validatedSubject = validateCurrentSubject(fileSystemNodePersistence);
-            final CavernConfig config = fileSystemNodePersistence.getConfig();
-            final PermissionsClientConfig permissionsClientConfig = config.getPermissionsClientConfig();
-            final Node inputNode = getInputNode();
+        final FileSystemNodePersistence fileSystemNodePersistence = getFileSystemNodePersistence();
+        final Subject validatedSubject = validateCurrentSubject(fileSystemNodePersistence);
+        final CavernConfig config = fileSystemNodePersistence.getConfig();
+        final PermissionsClientConfig permissionsClientConfig = config.getPermissionsClientConfig();
+        final Node inputNode = getInputNode();
 
-            if (shouldUsePermissionsClient(permissionsClientConfig, inputNode, fileSystemNodePersistence)) {
-                log.debug("Using permissions client to allocate user.");
-                final AuthorisationResult authorisationResult =
-                        authoriseAllocation(validatedSubject, permissionsClientConfig);
-                handleAuthenticatedAction(fileSystemNodePersistence, permissionsClientConfig, authorisationResult);
-            }
+        if (isSelfAllocation(validatedSubject, inputNode, fileSystemNodePersistence)) {
+            log.debug("Using permissions client to allocate user.");
+            final AuthorisationResult authorisationResult =
+                    authoriseAllocation(validatedSubject, permissionsClientConfig);
+            handleAuthenticatedAction(fileSystemNodePersistence, permissionsClientConfig, authorisationResult);
+        }
 
-            super.doAction();
+        super.doAction();
     }
 
-        private FileSystemNodePersistence getFileSystemNodePersistence() {
-            // Should never happen, but here for completeness.
-            if (this.nodePersistence instanceof FileSystemNodePersistence) {
-                return (FileSystemNodePersistence) this.nodePersistence;
-            }
-
-            throw new IllegalStateException("Node persistence is not an instance of FileSystemNodePersistence");
+    private FileSystemNodePersistence getFileSystemNodePersistence() {
+        // Should never happen, but here for completeness.
+        if (this.nodePersistence instanceof FileSystemNodePersistence) {
+            return (FileSystemNodePersistence) this.nodePersistence;
         }
 
-        private Subject validateCurrentSubject(final FileSystemNodePersistence fileSystemNodePersistence)
-                throws InvalidConfigException {
-            return fileSystemNodePersistence.getIdentityManager().validate(AuthenticationUtil.getCurrentSubject());
+        throw new IllegalStateException("Node persistence is not an instance of FileSystemNodePersistence");
+    }
+
+    private Subject validateCurrentSubject(final FileSystemNodePersistence fileSystemNodePersistence)
+            throws InvalidConfigException {
+        return fileSystemNodePersistence.getIdentityManager().validate(AuthenticationUtil.getCurrentSubject());
+    }
+
+    private boolean isSelfAllocation(final Subject callingSubject,
+                                     final Node inputNode,
+                                     final FileSystemNodePersistence fileSystemNodePersistence) {
+        final Subject owner = fileSystemNodePersistence.getRootNode().owner;
+        return !owner.equals(callingSubject)
+                && inputNode instanceof ContainerNode
+                && fileSystemNodePersistence.isAllocation(((ContainerNode) inputNode));
+    }
+
+    private AuthorisationResult authoriseAllocation(final Subject validatedSubject,
+                                                    final PermissionsClientConfig permissionsClientConfig)
+            throws Exception {
+        log.debug("permissions client config is present, validating permissions API token if present");
+        if (permissionsClientConfig == null) {
+            throw new IllegalStateException("Permissions client config is null");
         }
 
-        private boolean shouldUsePermissionsClient(final PermissionsClientConfig permissionsClientConfig,
-                                                   final Node inputNode,
-                                                   final FileSystemNodePersistence fileSystemNodePersistence) {
-            return permissionsClientConfig != null
-                    && inputNode instanceof ContainerNode
-                    && fileSystemNodePersistence.isAllocation(((ContainerNode) inputNode));
-        }
+        final PermissionsAPIClient permissionsAPIClient =
+                new PermissionsAPIClient(permissionsClientConfig.getPermissionsApiBaseUrl(),
+                        permissionsClientConfig.getPermissionsApiAuthBaseUrl());
 
-        private AuthorisationResult authoriseAllocation(final Subject validatedSubject,
-                                                        final PermissionsClientConfig permissionsClientConfig)
-                throws Exception {
-            log.debug("permissions client config is present, validating permissions API token if present");
+        return permissionsAPIClient.authoriseRoute(
+                permissionsClientConfig.getServiceName(),
+                getAuthorizationToken(validatedSubject).getCredentials(),
+                permissionsClientConfig.getRoutePath(),
+                permissionsClientConfig.getMethod(),
+                new JSONObject(),
+                permissionsClientConfig.getVersion());
+    }
 
-            final PermissionsAPIClient permissionsAPIClient =
-                    new PermissionsAPIClient(permissionsClientConfig.getPermissionsApiBaseUrl(),
-                            permissionsClientConfig.getPermissionsApiAuthBaseUrl());
-
-            return permissionsAPIClient.authoriseRoute(
-                    permissionsClientConfig.getServiceName(),
-                    getAuthorizationToken(validatedSubject).getCredentials(),
-                    permissionsClientConfig.getRoutePath(),
-                    permissionsClientConfig.getMethod(),
-                    new JSONObject(),
-                    permissionsClientConfig.getVersion());
-        }
-
-    private void handleAuthenticatedAction(FileSystemNodePersistence fileSystemNodePersistence,
-                                           PermissionsClientConfig permissionsClientConfig,
-                                           AuthorisationResult authorisationResult) throws Exception {
+    private void handleAuthenticatedAction(final FileSystemNodePersistence fileSystemNodePersistence,
+                                           final PermissionsClientConfig permissionsClientConfig,
+                                           final AuthorisationResult authorisationResult) throws Exception {
         if (authorisationResult.isAuthorised) {
             log.info("CAVERN ADMIN GRANT: " + permissionsClientConfig.getServiceName());
             Subject.doAs(fileSystemNodePersistence.getRootNode().owner, (PrivilegedExceptionAction<Void>) () -> {

--- a/cavern/src/main/java/org/opencadc/cavern/actions/CreateNodeAction.java
+++ b/cavern/src/main/java/org/opencadc/cavern/actions/CreateNodeAction.java
@@ -3,6 +3,7 @@ package org.opencadc.cavern.actions;
 import ca.nrc.cadc.auth.AuthenticationUtil;
 import ca.nrc.cadc.auth.AuthorizationToken;
 import java.security.AccessControlException;
+import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import javax.security.auth.Subject;
 import org.json.JSONObject;
@@ -24,6 +25,18 @@ public class CreateNodeAction extends org.opencadc.vospace.server.actions.Create
         if (isSelfAllocation()) {
             log.debug("Using permissions client to allocate user.");
             authorize();
+            try {
+                Subject.doAs(getFileSystemNodePersistence().getRootNode().owner, (PrivilegedExceptionAction<Void>) () -> {
+                    super.doAction();
+                    return null;
+                });
+            } catch (PrivilegedActionException e) {
+                // Use the underlying Exception as it's the relevant one.
+                if (e.getException() != null) {
+                    throw e.getException();
+                }
+                throw e;
+            }
         } else {
             // Handle normal create action.
             super.doAction();
@@ -72,16 +85,12 @@ public class CreateNodeAction extends org.opencadc.vospace.server.actions.Create
                 new JSONObject(),
                 permissionsClientConfig.getVersion());
 
-        if (authorisationResult.isAuthorised) {
-            log.info("CAVERN ADMIN GRANT: " + permissionsClientConfig.getServiceName());
-            Subject.doAs(fileSystemNodePersistence.getRootNode().owner, (PrivilegedExceptionAction<Void>) () -> {
-                super.doAction();
-                return null;
-            });
-        } else {
+        if (!authorisationResult.isAuthorised) {
             throw new AccessControlException(
                     "Subject is not authorized to create user allocations due to Permissions API Rules.");
         }
+
+        log.info("CAVERN ADMIN GRANT: " + permissionsClientConfig.getServiceName());
     }
 
     /**

--- a/cavern/src/main/java/org/opencadc/cavern/actions/CreateNodeAction.java
+++ b/cavern/src/main/java/org/opencadc/cavern/actions/CreateNodeAction.java
@@ -2,10 +2,8 @@ package org.opencadc.cavern.actions;
 
 import ca.nrc.cadc.auth.AuthenticationUtil;
 import ca.nrc.cadc.auth.AuthorizationToken;
-import ca.nrc.cadc.util.InvalidConfigException;
 import java.security.AccessControlException;
 import java.security.PrivilegedExceptionAction;
-import java.util.Objects;
 import javax.security.auth.Subject;
 import org.json.JSONObject;
 import org.opencadc.cavern.CavernConfig;
@@ -23,20 +21,13 @@ import org.opencadc.vospace.Node;
 public class CreateNodeAction extends org.opencadc.vospace.server.actions.CreateNodeAction {
     @Override
     public void doAction() throws Exception {
-        final FileSystemNodePersistence fileSystemNodePersistence = getFileSystemNodePersistence();
-        final Subject validatedSubject = validateCurrentSubject(fileSystemNodePersistence);
-        final Node inputNode = getInputNode();
-
-        if (isSelfAllocation(validatedSubject, inputNode, fileSystemNodePersistence)) {
+        if (isSelfAllocation()) {
             log.debug("Using permissions client to allocate user.");
-            final CavernConfig config = fileSystemNodePersistence.getConfig();
-            final PermissionsClientConfig permissionsClientConfig = config.getPermissionsClientConfig();
-            final AuthorisationResult authorisationResult =
-                    authoriseAllocation(validatedSubject, permissionsClientConfig);
-            handleAuthenticatedAction(fileSystemNodePersistence, permissionsClientConfig, authorisationResult);
+            authorize();
+        } else {
+            // Handle normal create action.
+            super.doAction();
         }
-
-        super.doAction();
     }
 
     private FileSystemNodePersistence getFileSystemNodePersistence() {
@@ -48,23 +39,22 @@ public class CreateNodeAction extends org.opencadc.vospace.server.actions.Create
         throw new IllegalStateException("Node persistence is not an instance of FileSystemNodePersistence");
     }
 
-    private Subject validateCurrentSubject(final FileSystemNodePersistence fileSystemNodePersistence)
-            throws InvalidConfigException {
-        return fileSystemNodePersistence.getIdentityManager().validate(AuthenticationUtil.getCurrentSubject());
-    }
-
-    private boolean isSelfAllocation(final Subject callingSubject,
-                                     final Node inputNode,
-                                     final FileSystemNodePersistence fileSystemNodePersistence) {
+    private boolean isSelfAllocation() {
+        final Subject caller = AuthenticationUtil.getCurrentSubject();
+        final Node inputNode = getInputNode();
+        final FileSystemNodePersistence fileSystemNodePersistence = getFileSystemNodePersistence();
         final Subject owner = fileSystemNodePersistence.getRootNode().owner;
-        return !owner.equals(callingSubject)
+        return !owner.equals(caller)
                 && inputNode instanceof ContainerNode
                 && fileSystemNodePersistence.isAllocation(((ContainerNode) inputNode));
     }
 
-    private AuthorisationResult authoriseAllocation(final Subject validatedSubject,
-                                                    final PermissionsClientConfig permissionsClientConfig)
-            throws Exception {
+    private void authorize() throws Exception {
+        final Subject caller = AuthenticationUtil.getCurrentSubject();
+        final FileSystemNodePersistence fileSystemNodePersistence = getFileSystemNodePersistence();
+        final CavernConfig config = fileSystemNodePersistence.getConfig();
+        final PermissionsClientConfig permissionsClientConfig = config.getPermissionsClientConfig();
+
         log.debug("permissions client config is present, validating permissions API token if present");
         if (permissionsClientConfig == null) {
             throw new IllegalStateException("Permissions client config is null");
@@ -74,18 +64,14 @@ public class CreateNodeAction extends org.opencadc.vospace.server.actions.Create
                 new PermissionsAPIClient(permissionsClientConfig.getPermissionsApiBaseUrl(),
                         permissionsClientConfig.getPermissionsApiAuthBaseUrl());
 
-        return permissionsAPIClient.authoriseRoute(
+        final AuthorisationResult authorisationResult = permissionsAPIClient.authoriseRoute(
                 permissionsClientConfig.getServiceName(),
-                getAuthorizationToken(validatedSubject).getCredentials(),
+                CreateNodeAction.getAuthorizationToken(caller).getCredentials(),
                 permissionsClientConfig.getRoutePath(),
                 permissionsClientConfig.getMethod(),
                 new JSONObject(),
                 permissionsClientConfig.getVersion());
-    }
 
-    private void handleAuthenticatedAction(final FileSystemNodePersistence fileSystemNodePersistence,
-                                           final PermissionsClientConfig permissionsClientConfig,
-                                           final AuthorisationResult authorisationResult) throws Exception {
         if (authorisationResult.isAuthorised) {
             log.info("CAVERN ADMIN GRANT: " + permissionsClientConfig.getServiceName());
             Subject.doAs(fileSystemNodePersistence.getRootNode().owner, (PrivilegedExceptionAction<Void>) () -> {

--- a/cavern/src/main/java/org/opencadc/cavern/actions/CreateNodeAction.java
+++ b/cavern/src/main/java/org/opencadc/cavern/actions/CreateNodeAction.java
@@ -12,6 +12,8 @@ import org.opencadc.cavern.PermissionsClientConfig;
 import org.opencadc.cavern.nodes.FileSystemNodePersistence;
 import org.opencadc.permissions.client.srcnet.AuthorisationResult;
 import org.opencadc.permissions.client.srcnet.PermissionsAPIClient;
+import org.opencadc.vospace.ContainerNode;
+import org.opencadc.vospace.Node;
 
 /**
  * Overridden create action to allow the use of a permissions client to access a remote service and do verification
@@ -33,8 +35,10 @@ public class CreateNodeAction extends org.opencadc.vospace.server.actions.Create
                 fileSystemNodePersistence.getIdentityManager().validate(AuthenticationUtil.getCurrentSubject());
         final CavernConfig config = fileSystemNodePersistence.getConfig();
         final PermissionsClientConfig permissionsClientConfig = config.getPermissionsClientConfig();
+        final Node inputNode = getInputNode();
         // Permissions Client was configured.
-        if (permissionsClientConfig != null) {
+        if (permissionsClientConfig != null && inputNode instanceof ContainerNode
+                && fileSystemNodePersistence.isAllocation(((ContainerNode) inputNode))) {
             log.debug("permissions client config is present, validating permissions API token if present");
             final PermissionsAPIClient permissionsAPIClient =
                     new PermissionsAPIClient(permissionsClientConfig.getPermissionsApiBaseUrl(),

--- a/cavern/src/main/java/org/opencadc/cavern/actions/CreateNodeAction.java
+++ b/cavern/src/main/java/org/opencadc/cavern/actions/CreateNodeAction.java
@@ -53,17 +53,17 @@ public class CreateNodeAction extends org.opencadc.vospace.server.actions.Create
         String path = uri.getPath();
         PosixPrincipal pp = getPosixUser(caller);
         if (pp == null || pp.username == null) {
-            throw new AccessControlException("permission denied: self-allocate " + uri.getURI().toASCIIString()
+            throw new AccessControlException("permission denied: self-allocate " + uri
                     + " reason: caller has no PosixPrincipal username");
         }
         String homeDir = "/home/" + pp.username; // TODO: get from local posix-mapper
         if (!path.equals(homeDir)) {
-            throw new AccessControlException("permission denied: self-allocate " + uri.getURI().toASCIIString()
+            throw new AccessControlException("permission denied: self-allocate " + uri
                     + " reason: target does not match expected home dir '" + homeDir + "'");
         }
 
         if (permissionsClientConfig != null) {
-            log.debug("permissions client config is present, validating permissions API token if present");
+            log.debug("calling Permissions API to authorise " + uri);
             final PermissionsAPIClient permissionsAPIClient =
                     new PermissionsAPIClient(permissionsClientConfig.getPermissionsApiBaseUrl(),
                             permissionsClientConfig.getPermissionsApiAuthBaseUrl());
@@ -71,7 +71,7 @@ public class CreateNodeAction extends org.opencadc.vospace.server.actions.Create
             final AuthorisationResult authorisationResult = permissionsAPIClient.authoriseRoute(
                     permissionsClientConfig.getServiceName(),
                     CreateNodeAction.getAuthorizationToken(caller).getCredentials(),
-                    permissionsClientConfig.getRoutePath(),
+                    uri.getPath(),
                     permissionsClientConfig.getMethod(),
                     new JSONObject(),
                     permissionsClientConfig.getVersion());
@@ -91,7 +91,7 @@ public class CreateNodeAction extends org.opencadc.vospace.server.actions.Create
             }
         }
         
-        throw new AccessControlException("permission denied: self-allocate " + uri.getURI().toASCIIString());
+        throw new AccessControlException("permission denied: self-allocate " + uri);
     }
 
     /**

--- a/cavern/src/main/java/org/opencadc/cavern/actions/CreateNodeAction.java
+++ b/cavern/src/main/java/org/opencadc/cavern/actions/CreateNodeAction.java
@@ -2,104 +2,96 @@ package org.opencadc.cavern.actions;
 
 import ca.nrc.cadc.auth.AuthenticationUtil;
 import ca.nrc.cadc.auth.AuthorizationToken;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
+import ca.nrc.cadc.auth.PosixPrincipal;
+import ca.nrc.cadc.cred.client.CredUtil;
+import java.security.AccessControlException;
+import java.util.Set;
 import javax.security.auth.Subject;
 import org.json.JSONObject;
 import org.opencadc.cavern.CavernConfig;
 import org.opencadc.cavern.PermissionsClientConfig;
 import org.opencadc.cavern.nodes.FileSystemNodePersistence;
+import org.opencadc.gms.GroupURI;
+import org.opencadc.gms.IvoaGroupClient;
 import org.opencadc.permissions.client.srcnet.AuthorisationResult;
 import org.opencadc.permissions.client.srcnet.PermissionsAPIClient;
-import org.opencadc.vospace.ContainerNode;
-import org.opencadc.vospace.Node;
-import org.opencadc.vospace.server.Utils;
+import org.opencadc.vospace.VOSURI;
 
 /**
  * Overridden create action to allow the use of a permissions client to access a remote service and do verification
  * that the caller has permissions to create an allocation.  Administrative access is then assumed.
  */
 public class CreateNodeAction extends org.opencadc.vospace.server.actions.CreateNodeAction {
-    @Override
-    public void doAction() throws Exception {
-        if (isSelfAllocation() && authorize()) {
-            log.debug("Using permissions client to allocate user.");
-
-            try {
-                final Node inputNode = getInputNode();
-                if (inputNode != null) {
-                    inputNode.ownerDisplay = getOwnerDisplay();
-                }
-                Subject.doAs(getFileSystemNodePersistence().getRootNode().owner, (PrivilegedExceptionAction<Void>) () -> {
-                    super.doAction();
-                    return null;
-                });
-                return;
-            } catch (PrivilegedActionException e) {
-                // Use the underlying Exception as it's the relevant one.
-                if (e.getException() != null) {
-                    throw e.getException();
-                }
-                throw e;
-            }
-        }
-
-        // Handle normal create action.
-        super.doAction();
-    }
-
+    
     private FileSystemNodePersistence getFileSystemNodePersistence() {
         // Should never happen, but here for completeness.
         if (this.nodePersistence instanceof FileSystemNodePersistence) {
             return (FileSystemNodePersistence) this.nodePersistence;
         }
 
-        throw new IllegalStateException("Node persistence is not an instance of FileSystemNodePersistence");
+        throw new RuntimeException("BUG: NodePersistence is not an instance of FileSystemNodePersistence");
     }
 
-    private String getOwnerDisplay() {
-        return getFileSystemNodePersistence().getIdentityManager().toDisplayString(
-                AuthenticationUtil.getCurrentSubject());
-    }
-
-    private boolean isSelfAllocation() {
-        final Subject caller = AuthenticationUtil.getCurrentSubject();
-        final Node inputNode = getInputNode();
-        final FileSystemNodePersistence fileSystemNodePersistence = getFileSystemNodePersistence();
-        return !Utils.isAdmin(caller, fileSystemNodePersistence)
-                && inputNode instanceof ContainerNode
-                && fileSystemNodePersistence.isAllocation(((ContainerNode) inputNode));
-    }
-
-    private boolean authorize() throws Exception {
-        final Subject caller = AuthenticationUtil.getCurrentSubject();
+    @Override
+    protected void checkSelfAllocatePermission(Subject caller, VOSURI uri) 
+            throws AccessControlException, Exception {
         final FileSystemNodePersistence fileSystemNodePersistence = getFileSystemNodePersistence();
         final CavernConfig config = fileSystemNodePersistence.getConfig();
+        
+        // two mechanisms to authorize self-allocate:
+        // cavern condfigured with self-allocate group
+        // cavern configured to use SRCNet Permissions API
+        final Set<GroupURI> allowedGroups = config.getSelfAllocateGroups();
         final PermissionsClientConfig permissionsClientConfig = config.getPermissionsClientConfig();
-
-        log.debug("permissions client config is present, validating permissions API token if present");
-        if (permissionsClientConfig == null) {
-            log.debug("permissions client config is null - could be a misconfiguration or intentional");
-            return false;
+        if (allowedGroups.isEmpty() && permissionsClientConfig == null) {
+            log.debug("self-allocate mechanism not configured -- could be a misconfiguration or intentional");
+            super.checkSelfAllocatePermission(caller, uri);
+            return;
         }
 
-        final PermissionsAPIClient permissionsAPIClient =
-                new PermissionsAPIClient(permissionsClientConfig.getPermissionsApiBaseUrl(),
-                        permissionsClientConfig.getPermissionsApiAuthBaseUrl());
+        // HACK: hard code restriction to allow home directory only
+        String path = uri.getPath();
+        PosixPrincipal pp = getPosixUser(caller);
+        if (pp == null || pp.username == null) {
+            throw new AccessControlException("permission denied: self-allocate " + uri.getURI().toASCIIString()
+                    + " reason: caller has no PosixPrincipal username");
+        }
+        String homeDir = "/home/" + pp.username; // TODO: get from local posix-mapper
+        if (!path.equals(homeDir)) {
+            throw new AccessControlException("permission denied: self-allocate " + uri.getURI().toASCIIString()
+                    + " reason: target does not match expected home dir '" + homeDir + "'");
+        }
 
-        final AuthorisationResult authorisationResult = permissionsAPIClient.authoriseRoute(
-                permissionsClientConfig.getServiceName(),
-                CreateNodeAction.getAuthorizationToken(caller).getCredentials(),
-                permissionsClientConfig.getRoutePath(),
-                permissionsClientConfig.getMethod(),
-                new JSONObject(),
-                permissionsClientConfig.getVersion());
+        if (permissionsClientConfig != null) {
+            log.debug("permissions client config is present, validating permissions API token if present");
+            final PermissionsAPIClient permissionsAPIClient =
+                    new PermissionsAPIClient(permissionsClientConfig.getPermissionsApiBaseUrl(),
+                            permissionsClientConfig.getPermissionsApiAuthBaseUrl());
 
-        final boolean isAuthorised = authorisationResult.isAuthorised;
+            final AuthorisationResult authorisationResult = permissionsAPIClient.authoriseRoute(
+                    permissionsClientConfig.getServiceName(),
+                    CreateNodeAction.getAuthorizationToken(caller).getCredentials(),
+                    permissionsClientConfig.getRoutePath(),
+                    permissionsClientConfig.getMethod(),
+                    new JSONObject(),
+                    permissionsClientConfig.getVersion());
 
-        log.debug("CAVERN ADMIN GRANT: " + permissionsClientConfig.getServiceName() + "(" + isAuthorised + ")");
-
-        return isAuthorised;
+            log.debug("self-allocate grant: " + permissionsClientConfig.getServiceName() + "(" + authorisationResult.isAuthorised + ")");
+            if (authorisationResult.isAuthorised) {
+                return;
+            }
+        }
+        
+        if (!allowedGroups.isEmpty()) {
+            IvoaGroupClient gms = new IvoaGroupClient();
+            CredUtil.checkCredentials(caller); // TODO: ignore return?
+            Set<GroupURI> mem = gms.getMemberships(allowedGroups);
+            if (!mem.isEmpty()) {
+                return;
+            }
+        }
+        
+        throw new AccessControlException("permission denied: self-allocate " + uri.getURI().toASCIIString());
     }
 
     /**
@@ -113,5 +105,9 @@ public class CreateNodeAction extends org.opencadc.vospace.server.actions.Create
                 .filter(token -> AuthenticationUtil.CHALLENGE_TYPE_BEARER.equalsIgnoreCase(token.getType()))
                 .findFirst()
                 .orElse(null);
+    }
+    
+    private PosixPrincipal getPosixUser(Subject subject) {
+        return subject.getPrincipals(PosixPrincipal.class).stream().findFirst().orElse(null);
     }
 }

--- a/cavern/src/main/java/org/opencadc/cavern/actions/CreateNodeAction.java
+++ b/cavern/src/main/java/org/opencadc/cavern/actions/CreateNodeAction.java
@@ -25,12 +25,12 @@ public class CreateNodeAction extends org.opencadc.vospace.server.actions.Create
     public void doAction() throws Exception {
         final FileSystemNodePersistence fileSystemNodePersistence = getFileSystemNodePersistence();
         final Subject validatedSubject = validateCurrentSubject(fileSystemNodePersistence);
-        final CavernConfig config = fileSystemNodePersistence.getConfig();
-        final PermissionsClientConfig permissionsClientConfig = config.getPermissionsClientConfig();
         final Node inputNode = getInputNode();
 
         if (isSelfAllocation(validatedSubject, inputNode, fileSystemNodePersistence)) {
             log.debug("Using permissions client to allocate user.");
+            final CavernConfig config = fileSystemNodePersistence.getConfig();
+            final PermissionsClientConfig permissionsClientConfig = config.getPermissionsClientConfig();
             final AuthorisationResult authorisationResult =
                     authoriseAllocation(validatedSubject, permissionsClientConfig);
             handleAuthenticatedAction(fileSystemNodePersistence, permissionsClientConfig, authorisationResult);

--- a/cavern/src/main/java/org/opencadc/cavern/actions/CreateNodeAction.java
+++ b/cavern/src/main/java/org/opencadc/cavern/actions/CreateNodeAction.java
@@ -2,7 +2,6 @@ package org.opencadc.cavern.actions;
 
 import ca.nrc.cadc.auth.AuthenticationUtil;
 import ca.nrc.cadc.auth.AuthorizationToken;
-import java.security.AccessControlException;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import javax.security.auth.Subject;
@@ -14,6 +13,7 @@ import org.opencadc.permissions.client.srcnet.AuthorisationResult;
 import org.opencadc.permissions.client.srcnet.PermissionsAPIClient;
 import org.opencadc.vospace.ContainerNode;
 import org.opencadc.vospace.Node;
+import org.opencadc.vospace.server.Utils;
 
 /**
  * Overridden create action to allow the use of a permissions client to access a remote service and do verification
@@ -22,14 +22,19 @@ import org.opencadc.vospace.Node;
 public class CreateNodeAction extends org.opencadc.vospace.server.actions.CreateNodeAction {
     @Override
     public void doAction() throws Exception {
-        if (isSelfAllocation()) {
+        if (isSelfAllocation() && authorize()) {
             log.debug("Using permissions client to allocate user.");
-            authorize();
+
             try {
+                final Node inputNode = getInputNode();
+                if (inputNode != null) {
+                    inputNode.ownerDisplay = getOwnerDisplay();
+                }
                 Subject.doAs(getFileSystemNodePersistence().getRootNode().owner, (PrivilegedExceptionAction<Void>) () -> {
                     super.doAction();
                     return null;
                 });
+                return;
             } catch (PrivilegedActionException e) {
                 // Use the underlying Exception as it's the relevant one.
                 if (e.getException() != null) {
@@ -37,10 +42,10 @@ public class CreateNodeAction extends org.opencadc.vospace.server.actions.Create
                 }
                 throw e;
             }
-        } else {
-            // Handle normal create action.
-            super.doAction();
         }
+
+        // Handle normal create action.
+        super.doAction();
     }
 
     private FileSystemNodePersistence getFileSystemNodePersistence() {
@@ -52,17 +57,21 @@ public class CreateNodeAction extends org.opencadc.vospace.server.actions.Create
         throw new IllegalStateException("Node persistence is not an instance of FileSystemNodePersistence");
     }
 
+    private String getOwnerDisplay() {
+        return getFileSystemNodePersistence().getIdentityManager().toDisplayString(
+                AuthenticationUtil.getCurrentSubject());
+    }
+
     private boolean isSelfAllocation() {
         final Subject caller = AuthenticationUtil.getCurrentSubject();
         final Node inputNode = getInputNode();
         final FileSystemNodePersistence fileSystemNodePersistence = getFileSystemNodePersistence();
-        final Subject owner = fileSystemNodePersistence.getRootNode().owner;
-        return !owner.equals(caller)
+        return !Utils.isAdmin(caller, fileSystemNodePersistence)
                 && inputNode instanceof ContainerNode
                 && fileSystemNodePersistence.isAllocation(((ContainerNode) inputNode));
     }
 
-    private void authorize() throws Exception {
+    private boolean authorize() throws Exception {
         final Subject caller = AuthenticationUtil.getCurrentSubject();
         final FileSystemNodePersistence fileSystemNodePersistence = getFileSystemNodePersistence();
         final CavernConfig config = fileSystemNodePersistence.getConfig();
@@ -70,7 +79,8 @@ public class CreateNodeAction extends org.opencadc.vospace.server.actions.Create
 
         log.debug("permissions client config is present, validating permissions API token if present");
         if (permissionsClientConfig == null) {
-            throw new IllegalStateException("Permissions client config is null");
+            log.debug("permissions client config is null - could be a misconfiguration or intentional");
+            return false;
         }
 
         final PermissionsAPIClient permissionsAPIClient =
@@ -85,12 +95,11 @@ public class CreateNodeAction extends org.opencadc.vospace.server.actions.Create
                 new JSONObject(),
                 permissionsClientConfig.getVersion());
 
-        if (!authorisationResult.isAuthorised) {
-            throw new AccessControlException(
-                    "Subject is not authorized to create user allocations due to Permissions API Rules.");
-        }
+        final boolean isAuthorised = authorisationResult.isAuthorised;
 
-        log.info("CAVERN ADMIN GRANT: " + permissionsClientConfig.getServiceName());
+        log.debug("CAVERN ADMIN GRANT: " + permissionsClientConfig.getServiceName() + "(" + isAuthorised + ")");
+
+        return isAuthorised;
     }
 
     /**

--- a/cavern/src/main/java/org/opencadc/cavern/actions/CreateNodeAction.java
+++ b/cavern/src/main/java/org/opencadc/cavern/actions/CreateNodeAction.java
@@ -22,53 +22,61 @@ import org.opencadc.vospace.Node;
 public class CreateNodeAction extends org.opencadc.vospace.server.actions.CreateNodeAction {
     @Override
     public void doAction() throws Exception {
-        final FileSystemNodePersistence fileSystemNodePersistence;
+            final FileSystemNodePersistence fileSystemNodePersistence = getFileSystemNodePersistence();
+            final Subject validatedSubject = validateCurrentSubject(fileSystemNodePersistence);
+            final CavernConfig config = fileSystemNodePersistence.getConfig();
+            final PermissionsClientConfig permissionsClientConfig = config.getPermissionsClientConfig();
+            final Node inputNode = getInputNode();
 
-        // Should never happen, but here for completeness.
-        if (this.nodePersistence instanceof FileSystemNodePersistence) {
-            fileSystemNodePersistence = (FileSystemNodePersistence) this.nodePersistence;
-        } else {
+            if (shouldUsePermissionsClient(permissionsClientConfig, inputNode, fileSystemNodePersistence)) {
+                log.debug("Using permissions client to allocate user.");
+                final AuthorisationResult authorisationResult =
+                        authoriseAllocation(validatedSubject, permissionsClientConfig);
+                handleAuthenticatedAction(fileSystemNodePersistence, permissionsClientConfig, authorisationResult);
+            }
+
+            super.doAction();
+    }
+
+        private FileSystemNodePersistence getFileSystemNodePersistence() {
+            // Should never happen, but here for completeness.
+            if (this.nodePersistence instanceof FileSystemNodePersistence) {
+                return (FileSystemNodePersistence) this.nodePersistence;
+            }
+
             throw new IllegalStateException("Node persistence is not an instance of FileSystemNodePersistence");
         }
 
-        final Subject validatedSubject =
-                fileSystemNodePersistence.getIdentityManager().validate(AuthenticationUtil.getCurrentSubject());
-        final CavernConfig config = fileSystemNodePersistence.getConfig();
-        final PermissionsClientConfig permissionsClientConfig = config.getPermissionsClientConfig();
-        final Node inputNode = getInputNode();
-        // Permissions Client was configured.
-        if (permissionsClientConfig != null && inputNode instanceof ContainerNode
-                && fileSystemNodePersistence.isAllocation(((ContainerNode) inputNode))) {
+        private Subject validateCurrentSubject(final FileSystemNodePersistence fileSystemNodePersistence)
+                throws InvalidConfigException {
+            return fileSystemNodePersistence.getIdentityManager().validate(AuthenticationUtil.getCurrentSubject());
+        }
+
+        private boolean shouldUsePermissionsClient(final PermissionsClientConfig permissionsClientConfig,
+                                                   final Node inputNode,
+                                                   final FileSystemNodePersistence fileSystemNodePersistence) {
+            return permissionsClientConfig != null
+                    && inputNode instanceof ContainerNode
+                    && fileSystemNodePersistence.isAllocation(((ContainerNode) inputNode));
+        }
+
+        private AuthorisationResult authoriseAllocation(final Subject validatedSubject,
+                                                        final PermissionsClientConfig permissionsClientConfig)
+                throws Exception {
             log.debug("permissions client config is present, validating permissions API token if present");
+
             final PermissionsAPIClient permissionsAPIClient =
                     new PermissionsAPIClient(permissionsClientConfig.getPermissionsApiBaseUrl(),
                             permissionsClientConfig.getPermissionsApiAuthBaseUrl());
-            final AuthorisationResult authorisationResult;
-            if (permissionsClientConfig.getAuthoriseType().equalsIgnoreCase("plugin")) {
-                log.debug("Authorising with plugin type");
-                authorisationResult = permissionsAPIClient.authorisePlugin(
-                        permissionsClientConfig.getServiceName(),
-                        getAuthorizationToken(validatedSubject).getCredentials(),
-                        new JSONObject(),
-                        permissionsClientConfig.getVersion());
-            } else if (permissionsClientConfig.getAuthoriseType().equalsIgnoreCase("route")) {
-                log.debug("Authorising with route type");
-                authorisationResult = permissionsAPIClient.authoriseRoute(
-                        permissionsClientConfig.getServiceName(),
-                        getAuthorizationToken(validatedSubject).getCredentials(),
-                        permissionsClientConfig.getRoutePath(),
-                        permissionsClientConfig.getMethod(),
-                        new JSONObject(),
-                        permissionsClientConfig.getVersion());
-            } else {
-                throw new InvalidConfigException("Invalid authoriseType in permissions client config: "
-                        + permissionsClientConfig.getAuthoriseType());
-            }
 
-            handleAuthenticatedAction(fileSystemNodePersistence, permissionsClientConfig, authorisationResult);
+            return permissionsAPIClient.authoriseRoute(
+                    permissionsClientConfig.getServiceName(),
+                    getAuthorizationToken(validatedSubject).getCredentials(),
+                    permissionsClientConfig.getRoutePath(),
+                    permissionsClientConfig.getMethod(),
+                    new JSONObject(),
+                    permissionsClientConfig.getVersion());
         }
-        super.doAction();
-    }
 
     private void handleAuthenticatedAction(FileSystemNodePersistence fileSystemNodePersistence,
                                            PermissionsClientConfig permissionsClientConfig,

--- a/cavern/src/main/java/org/opencadc/cavern/actions/CreateNodeAction.java
+++ b/cavern/src/main/java/org/opencadc/cavern/actions/CreateNodeAction.java
@@ -1,0 +1,96 @@
+package org.opencadc.cavern.actions;
+
+import ca.nrc.cadc.auth.AuthenticationUtil;
+import ca.nrc.cadc.auth.AuthorizationToken;
+import ca.nrc.cadc.util.InvalidConfigException;
+import java.security.AccessControlException;
+import java.security.PrivilegedExceptionAction;
+import javax.security.auth.Subject;
+import org.json.JSONObject;
+import org.opencadc.cavern.CavernConfig;
+import org.opencadc.cavern.PermissionsClientConfig;
+import org.opencadc.cavern.nodes.FileSystemNodePersistence;
+import org.opencadc.permissions.client.srcnet.AuthorisationResult;
+import org.opencadc.permissions.client.srcnet.PermissionsAPIClient;
+
+/**
+ * Overridden create action to allow the use of a permissions client to access a remote service and do verification
+ * that the caller has permissions to create an allocation.  Administrative access is then assumed.
+ */
+public class CreateNodeAction extends org.opencadc.vospace.server.actions.CreateNodeAction {
+    @Override
+    public void doAction() throws Exception {
+        final FileSystemNodePersistence fileSystemNodePersistence;
+
+        // Should never happen, but here for completeness.
+        if (this.nodePersistence instanceof FileSystemNodePersistence) {
+            fileSystemNodePersistence = (FileSystemNodePersistence) this.nodePersistence;
+        } else {
+            throw new IllegalStateException("Node persistence is not an instance of FileSystemNodePersistence");
+        }
+
+        final Subject validatedSubject =
+                fileSystemNodePersistence.getIdentityManager().validate(AuthenticationUtil.getCurrentSubject());
+        final CavernConfig config = fileSystemNodePersistence.getConfig();
+        final PermissionsClientConfig permissionsClientConfig = config.getPermissionsClientConfig();
+        // Permissions Client was configured.
+        if (permissionsClientConfig != null) {
+            log.debug("permissions client config is present, validating permissions API token if present");
+            final PermissionsAPIClient permissionsAPIClient =
+                    new PermissionsAPIClient(permissionsClientConfig.getPermissionsApiBaseUrl(),
+                            permissionsClientConfig.getPermissionsApiAuthBaseUrl());
+            final AuthorisationResult authorisationResult;
+            if (permissionsClientConfig.getAuthoriseType().equalsIgnoreCase("plugin")) {
+                log.debug("Authorising with plugin type");
+                authorisationResult = permissionsAPIClient.authorisePlugin(
+                        permissionsClientConfig.getServiceName(),
+                        getAuthorizationToken(validatedSubject).getCredentials(),
+                        new JSONObject(),
+                        permissionsClientConfig.getVersion());
+            } else if (permissionsClientConfig.getAuthoriseType().equalsIgnoreCase("route")) {
+                log.debug("Authorising with route type");
+                authorisationResult = permissionsAPIClient.authoriseRoute(
+                        permissionsClientConfig.getServiceName(),
+                        getAuthorizationToken(validatedSubject).getCredentials(),
+                        permissionsClientConfig.getRoutePath(),
+                        permissionsClientConfig.getMethod(),
+                        new JSONObject(),
+                        permissionsClientConfig.getVersion());
+            } else {
+                throw new InvalidConfigException("Invalid authoriseType in permissions client config: "
+                        + permissionsClientConfig.getAuthoriseType());
+            }
+
+            handleAuthenticatedAction(fileSystemNodePersistence, permissionsClientConfig, authorisationResult);
+        }
+        super.doAction();
+    }
+
+    private void handleAuthenticatedAction(FileSystemNodePersistence fileSystemNodePersistence,
+                                           PermissionsClientConfig permissionsClientConfig,
+                                           AuthorisationResult authorisationResult) throws Exception {
+        if (authorisationResult.isAuthorised) {
+            log.info("CAVERN ADMIN GRANT: " + permissionsClientConfig.getServiceName());
+            Subject.doAs(fileSystemNodePersistence.getRootNode().owner, (PrivilegedExceptionAction<Void>) () -> {
+                super.doAction();
+                return null;
+            });
+        } else {
+            throw new AccessControlException(
+                    "Subject is not authorized to create user allocations due to Permissions API Rules.");
+        }
+    }
+
+    /**
+     * Obtain the given Subject's bearer token. Null if none found.,
+     *
+     * @param subject The Subject to look through.
+     * @return AuthorizationToken with type "Bearer", or null if none found.
+     */
+    public static AuthorizationToken getAuthorizationToken(final Subject subject) {
+        return subject.getPublicCredentials(AuthorizationToken.class).stream()
+                .filter(token -> AuthenticationUtil.CHALLENGE_TYPE_BEARER.equalsIgnoreCase(token.getType()))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/cavern/src/main/java/org/opencadc/cavern/nodes/PosixIdentityManager.java
+++ b/cavern/src/main/java/org/opencadc/cavern/nodes/PosixIdentityManager.java
@@ -67,28 +67,17 @@
 
 package org.opencadc.cavern.nodes;
 
-import ca.nrc.cadc.auth.AuthenticationUtil;
-import ca.nrc.cadc.auth.AuthorizationToken;
 import ca.nrc.cadc.auth.IdentityManager;
 import ca.nrc.cadc.auth.NotAuthenticatedException;
 import ca.nrc.cadc.auth.PosixPrincipal;
 import ca.nrc.cadc.util.InvalidConfigException;
-import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import javax.naming.Context;
-import javax.naming.InitialContext;
-import javax.naming.NamingException;
 import javax.security.auth.Subject;
 import org.apache.log4j.Logger;
-import org.json.JSONObject;
-import org.opencadc.cavern.CavernConfig;
-import org.opencadc.cavern.PermissionsClientConfig;
-import org.opencadc.permissions.client.srcnet.AuthorisationResult;
-import org.opencadc.permissions.client.srcnet.PermissionsAPIClient;
 import org.opencadc.vospace.server.NodePersistence;
 
 /**
@@ -216,77 +205,11 @@ public class PosixIdentityManager implements IdentityManager {
     public Subject validate(Subject subject) throws NotAuthenticatedException {
         if (subject != null) {
             // delegate to the configured IdentityManager
-            final Subject validatedSubject = this.wrappedIdentityManager.validate(subject);
-
-            try {
-                Context ctx = new InitialContext();
-                FileSystemNodePersistence fileSystemNodePersistence =
-                        (FileSystemNodePersistence) ctx.lookup(PosixIdentityManager.JNDI_NODE_PERSISTENCE_PROPERTY);
-                final CavernConfig config = fileSystemNodePersistence.getConfig();
-                final PermissionsClientConfig permissionsClientConfig = config.getPermissionsClientConfig();
-                // Permissions Client was configured.
-                if (permissionsClientConfig != null) {
-                    log.debug("permissions client config is present, validating permissions API token if present");
-                    final PermissionsAPIClient permissionsAPIClient =
-                            new PermissionsAPIClient(permissionsClientConfig.getPermissionsApiBaseUrl(),
-                                    permissionsClientConfig.getPermissionsApiAuthBaseUrl());
-                    switch (permissionsClientConfig.getAuthoriseType().toLowerCase()) {
-                        case "plugin": {
-                            AuthorisationResult pluginResult = permissionsAPIClient.authorisePlugin(
-                                    permissionsClientConfig.getServiceName(),
-                                    getAuthorizationToken(validatedSubject).getCredentials(),
-                                    new JSONObject(),
-                                    permissionsClientConfig.getVersion());
-
-                            if (pluginResult.isAuthorised) {
-                                log.info("CAVERN ADMIN GRANT: " + permissionsClientConfig.getServiceName());
-                                return fileSystemNodePersistence.getRootNode().owner;
-                            }
-                            break;
-                        }
-                        case "route": {
-                            AuthorisationResult routeResult = permissionsAPIClient.authoriseRoute(
-                                    permissionsClientConfig.getServiceName(),
-                                    getAuthorizationToken(validatedSubject).getCredentials(),
-                                    permissionsClientConfig.getRoutePath(),
-                                    permissionsClientConfig.getMethod(),
-                                    new JSONObject(),
-                                    permissionsClientConfig.getVersion());
-
-                            if (routeResult.isAuthorised) {
-                                log.info("CAVERN ADMIN GRANT: " + permissionsClientConfig.getServiceName());
-                                return fileSystemNodePersistence.getRootNode().owner;
-                            }
-                            break;
-                        }
-                        default: {
-                            log.warn("invalid authoriseType in permissions client config: "
-                                    + permissionsClientConfig.getAuthoriseType());
-                        }
-                    }
-                }
-            } catch (NamingException | IOException exception) {
-                throw new IllegalStateException(exception.getMessage(), exception);
-            }
-
-            return validatedSubject;
+            return this.wrappedIdentityManager.validate(subject);
         }
 
         // if subject is null, return null
         return null;
-    }
-
-    /**
-     * Obtain the given Subject's bearer token. Null if none found.,
-     *
-     * @param subject The Subject to look through.
-     * @return AuthorizationToken with type "Bearer", or null if none found.
-     */
-    public static AuthorizationToken getAuthorizationToken(final Subject subject) {
-        return subject.getPublicCredentials(AuthorizationToken.class).stream()
-                .filter(token -> AuthenticationUtil.CHALLENGE_TYPE_BEARER.equalsIgnoreCase(token.getType()))
-                .findFirst()
-                .orElse(null);
     }
 
     @Override

--- a/cavern/src/main/java/org/opencadc/cavern/nodes/PosixIdentityManager.java
+++ b/cavern/src/main/java/org/opencadc/cavern/nodes/PosixIdentityManager.java
@@ -67,11 +67,13 @@
 
 package org.opencadc.cavern.nodes;
 
-import ca.nrc.cadc.auth.AuthorizationTokenPrincipal;
+import ca.nrc.cadc.auth.AuthenticationUtil;
+import ca.nrc.cadc.auth.AuthorizationToken;
 import ca.nrc.cadc.auth.IdentityManager;
 import ca.nrc.cadc.auth.NotAuthenticatedException;
 import ca.nrc.cadc.auth.PosixPrincipal;
 import ca.nrc.cadc.util.InvalidConfigException;
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.util.Map;
@@ -82,7 +84,11 @@ import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import javax.security.auth.Subject;
 import org.apache.log4j.Logger;
+import org.json.JSONObject;
 import org.opencadc.cavern.CavernConfig;
+import org.opencadc.cavern.PermissionsClientConfig;
+import org.opencadc.permissions.client.srcnet.AuthorisationResult;
+import org.opencadc.permissions.client.srcnet.PermissionsAPIClient;
 import org.opencadc.vospace.server.NodePersistence;
 
 /**
@@ -212,37 +218,54 @@ public class PosixIdentityManager implements IdentityManager {
             // delegate to the configured IdentityManager
             final Subject validatedSubject = this.wrappedIdentityManager.validate(subject);
 
-            final Set<AuthorizationTokenPrincipal> tokenPrincipals = validatedSubject.getPrincipals(AuthorizationTokenPrincipal.class);
-            for (final AuthorizationTokenPrincipal tokenPrincipal : tokenPrincipals) {
-                final String tokenHeaderValue = tokenPrincipal.getHeaderValue();
-                final String[] parts = tokenHeaderValue.split(" ", 2);
-                if (parts.length == 2) {
-                    final String challengeType = parts[0];
-                    if (CavernConfig.ALLOCATION_API_KEY_HEADER_CHALLENGE_TYPE.equalsIgnoreCase(challengeType)) {
-                        final String tokenValue = parts[1].trim();
-                        final String[] tokenValueParts = tokenValue.split(":", 2);
-                        if (tokenValueParts.length == 2) {
-                            final String clientApplicationName = tokenValueParts[0].trim();
-                            final String apiKeyToken = tokenValueParts[1].trim();
-                            try {
-                                Context ctx = new InitialContext();
-                                FileSystemNodePersistence fileSystemNodePersistence = 
-                                        (FileSystemNodePersistence) ctx.lookup(PosixIdentityManager.JNDI_NODE_PERSISTENCE_PROPERTY);
-                                CavernConfig config = fileSystemNodePersistence.getConfig();
-                                Map<String, String> apiKeys = config.getAdminAPIKeys();
+            try {
+                Context ctx = new InitialContext();
+                FileSystemNodePersistence fileSystemNodePersistence =
+                        (FileSystemNodePersistence) ctx.lookup(PosixIdentityManager.JNDI_NODE_PERSISTENCE_PROPERTY);
+                final CavernConfig config = fileSystemNodePersistence.getConfig();
+                final PermissionsClientConfig permissionsClientConfig = config.getPermissionsClientConfig();
+                // Permissions Client was configured.
+                if (permissionsClientConfig != null) {
+                    log.debug("permissions client config is present, validating permissions API token if present");
+                    final PermissionsAPIClient permissionsAPIClient =
+                            new PermissionsAPIClient(permissionsClientConfig.getPermissionsApiBaseUrl(),
+                                    permissionsClientConfig.getPermissionsApiAuthBaseUrl());
+                    switch (permissionsClientConfig.getAuthoriseType().toLowerCase()) {
+                        case "plugin": {
+                            AuthorisationResult pluginResult = permissionsAPIClient.authorisePlugin(
+                                    permissionsClientConfig.getServiceName(),
+                                    getAuthorizationToken(validatedSubject).getCredentials(),
+                                    new JSONObject(),
+                                    permissionsClientConfig.getVersion());
 
-                                if (apiKeys.containsKey(clientApplicationName) && apiKeys.get(clientApplicationName).equals(apiKeyToken)) {
-                                    log.info("CAVERN ADMIN GRANT: " + clientApplicationName);
-                                    return fileSystemNodePersistence.getRootNode().owner;
-                                }
-                            } catch (NamingException namingException) {
-                                throw new IllegalStateException(namingException.getMessage(), namingException);
+                            if (pluginResult.isAuthorised) {
+                                log.info("CAVERN ADMIN GRANT: " + permissionsClientConfig.getServiceName());
+                                return fileSystemNodePersistence.getRootNode().owner;
                             }
+                            break;
                         }
-                        // intentionally vague error message for failed admin-api-key
-                        throw new NotAuthenticatedException("invalid token");
+                        case "route": {
+                            AuthorisationResult result = permissionsAPIClient.authoriseRoute(
+                                    permissionsClientConfig.getServiceName(),
+                                    getAuthorizationToken(validatedSubject).getCredentials(),
+                                    permissionsClientConfig.getRoutePath(),
+                                    permissionsClientConfig.getMethod(),
+                                    new JSONObject(),
+                                    permissionsClientConfig.getVersion());
+
+                            if (result.isAuthorised) {
+                                log.info("CAVERN ADMIN GRANT: " + permissionsClientConfig.getServiceName());
+                                return fileSystemNodePersistence.getRootNode().owner;
+                            }
+                            break;
+                        }
+                        default: {
+                            log.warn("invalid authoriseType in permissions client config: " + permissionsClientConfig.getAuthoriseType());
+                        }
                     }
                 }
+            } catch (NamingException | IOException exception) {
+                throw new IllegalStateException(exception.getMessage(), exception);
             }
 
             return validatedSubject;
@@ -252,15 +275,17 @@ public class PosixIdentityManager implements IdentityManager {
         return null;
     }
 
-    private Map<String, String> getAdminAPIKeys() {
-        try {
-            final Context ctx = new InitialContext();
-            final FileSystemNodePersistence fileSystemNodePersistence = (FileSystemNodePersistence) ctx.lookup("cavern-" + NodePersistence.class.getName());
-            final CavernConfig config = fileSystemNodePersistence.getConfig();
-            return config.getAdminAPIKeys();
-        } catch (NamingException namingException) {
-            throw new IllegalStateException(namingException.getMessage(), namingException);
-        }
+    /**
+     * Obtain the given Subject's bearer token. Null if none found.,
+     *
+     * @param subject The Subject to look through.
+     * @return AuthorizationToken with type "Bearer", or null if none found.
+     */
+    public static AuthorizationToken getAuthorizationToken(final Subject subject) {
+        return subject.getPublicCredentials(AuthorizationToken.class).stream()
+                .filter(token -> AuthenticationUtil.CHALLENGE_TYPE_BEARER.equalsIgnoreCase(token.getType()))
+                .findFirst()
+                .orElse(null);
     }
 
     @Override

--- a/cavern/src/main/java/org/opencadc/cavern/nodes/PosixIdentityManager.java
+++ b/cavern/src/main/java/org/opencadc/cavern/nodes/PosixIdentityManager.java
@@ -245,7 +245,7 @@ public class PosixIdentityManager implements IdentityManager {
                             break;
                         }
                         case "route": {
-                            AuthorisationResult result = permissionsAPIClient.authoriseRoute(
+                            AuthorisationResult routeResult = permissionsAPIClient.authoriseRoute(
                                     permissionsClientConfig.getServiceName(),
                                     getAuthorizationToken(validatedSubject).getCredentials(),
                                     permissionsClientConfig.getRoutePath(),
@@ -253,7 +253,7 @@ public class PosixIdentityManager implements IdentityManager {
                                     new JSONObject(),
                                     permissionsClientConfig.getVersion());
 
-                            if (result.isAuthorised) {
+                            if (routeResult.isAuthorised) {
                                 log.info("CAVERN ADMIN GRANT: " + permissionsClientConfig.getServiceName());
                                 return fileSystemNodePersistence.getRootNode().owner;
                             }

--- a/cavern/src/main/java/org/opencadc/cavern/nodes/PosixIdentityManager.java
+++ b/cavern/src/main/java/org/opencadc/cavern/nodes/PosixIdentityManager.java
@@ -260,7 +260,8 @@ public class PosixIdentityManager implements IdentityManager {
                             break;
                         }
                         default: {
-                            log.warn("invalid authoriseType in permissions client config: " + permissionsClientConfig.getAuthoriseType());
+                            log.warn("invalid authoriseType in permissions client config: "
+                                    + permissionsClientConfig.getAuthoriseType());
                         }
                     }
                 }

--- a/cavern/src/main/webapp/WEB-INF/web.xml
+++ b/cavern/src/main/webapp/WEB-INF/web.xml
@@ -53,7 +53,7 @@
         </init-param>
         <init-param>
             <param-name>put</param-name>
-            <param-value>org.opencadc.vospace.server.actions.CreateNodeAction</param-value>
+            <param-value>org.opencadc.cavern.actions.CreateNodeAction</param-value>
         </init-param>
         <init-param>
             <param-name>post</param-name>


### PR DESCRIPTION
I have not documented the configuration but by configuring a `selfAllocateGroup` I was able to make all the rejections happen as intended.

I still have to fix the cadc-test-vos setup because it relied on `allocationParent=/`.