### PR TITLE
fix: fix for papi call with the home path wildcard

### DIFF
--- a/cavern/VERSION
+++ b/cavern/VERSION
@@ -1,6 +1,6 @@
 ## deployable containers have a semantic and build tag
 # semantic version tag: major.minor
 # build version tag: timestamp
-VER=0.10.1
+VER=0.10.2
 TAGS="${VER} ${VER}-$(date -u +"%Y%m%dT%H%M%S")"
 unset VER

--- a/cavern/src/main/java/org/opencadc/cavern/actions/CreateNodeAction.java
+++ b/cavern/src/main/java/org/opencadc/cavern/actions/CreateNodeAction.java
@@ -22,6 +22,9 @@ import org.opencadc.vospace.VOSURI;
  * that the caller has permissions to create an allocation.  Administrative access is then assumed.
  */
 public class CreateNodeAction extends org.opencadc.vospace.server.actions.CreateNodeAction {
+
+    private static final String PERMISSIONS_API_ROUTE_KEY = "username";
+    private static final String PERMISSIONS_API_ROUTE = "/home/{" + CreateNodeAction.PERMISSIONS_API_ROUTE_KEY + "}";
     
     private FileSystemNodePersistence getFileSystemNodePersistence() {
         // Should never happen, but here for completeness.
@@ -33,13 +36,12 @@ public class CreateNodeAction extends org.opencadc.vospace.server.actions.Create
     }
 
     @Override
-    protected void checkSelfAllocatePermission(Subject caller, VOSURI uri) 
-            throws AccessControlException, Exception {
+    protected void checkSelfAllocatePermission(Subject caller, VOSURI uri) throws Exception {
         final FileSystemNodePersistence fileSystemNodePersistence = getFileSystemNodePersistence();
         final CavernConfig config = fileSystemNodePersistence.getConfig();
         
         // two mechanisms to authorize self-allocate:
-        // cavern condfigured with self-allocate group
+        // cavern configured with self-allocate group
         // cavern configured to use SRCNet Permissions API
         final Set<GroupURI> allowedGroups = config.getSelfAllocateGroups();
         final PermissionsClientConfig permissionsClientConfig = config.getPermissionsClientConfig();
@@ -68,12 +70,16 @@ public class CreateNodeAction extends org.opencadc.vospace.server.actions.Create
                     new PermissionsAPIClient(permissionsClientConfig.getPermissionsApiBaseUrl(),
                             permissionsClientConfig.getPermissionsApiAuthBaseUrl());
 
+            // The JSON body with the username value set.
+            final JSONObject jsonBody = new JSONObject();
+            jsonBody.put(CreateNodeAction.PERMISSIONS_API_ROUTE_KEY, pp.username);
+
             final AuthorisationResult authorisationResult = permissionsAPIClient.authoriseRoute(
                     permissionsClientConfig.getServiceName(),
-                    uri.getPath(),
+                    CreateNodeAction.PERMISSIONS_API_ROUTE,
                     CreateNodeAction.getAuthorizationToken(caller).getCredentials(),
                     permissionsClientConfig.getMethod(),
-                    new JSONObject(),
+                    jsonBody,
                     permissionsClientConfig.getVersion());
 
             log.debug("self-allocate grant: " + permissionsClientConfig.getServiceName() + "(" + authorisationResult.isAuthorised + ")");


### PR DESCRIPTION
# Changes
The Permissions API needs to have the path match exactly (`/home/{username}`), and the actual username needs to be in the JSON body that gets POSTed:
```
curl --header "content-type: application/json" --data '{"username": "myusername"}' "https://permissions.srcnet.skao.int/api/v1/authorise/route/canfar-api?method=PUT&route=%2Fhome%2F%7Busername%7D&token=..."
```